### PR TITLE
Fixed table timeout bug

### DIFF
--- a/src/game.go
+++ b/src/game.go
@@ -366,7 +366,7 @@ func (g *Game) CheckIdle() {
 	defer commandMutex.Unlock()
 
 	// Don't do anything if there has been an action in the meantime
-	if time.Since(g.DatetimeLastAction) < idleTimeout {
+	if time.Since(g.DatetimeLastAction) > idleTimeout {
 		return
 	}
 


### PR DESCRIPTION
Fixed the bug that caused any games that go above a total duration of 30 minutes and 1 second to be instantly killed.