### PR TITLE
Use emojis instead of red circles as the character indicator

### DIFF
--- a/public/js/constants.js
+++ b/public/js/constants.js
@@ -1010,60 +1010,73 @@
         new CharacterAssignment(
             'Conservative',
             'Can only give clues that touch a single card',
+            '💼',
         ),
         new CharacterAssignment(
             'Greedy',
             'Can only give clues that touch 2+ cards',
+            '🤑',
         ),
         new CharacterAssignment(
             'Fuming',
             'Can only clue numbers and [random color]',
+            '🌋',
         ),
         new CharacterAssignment(
             'Dumbfounded',
             'Can only clue colors and [random number]',
+            '🤯',
         ),
         new CharacterAssignment(
             'Picky',
             'Can only clue odd numbers or odd colors',
+            '🤢',
         ),
         new CharacterAssignment(
             'Spiteful',
             'Cannot clue the player to their left',
+            '😈',
         ),
         new CharacterAssignment(
             'Insolent',
             'Cannot clue the player to their right',
+            '😏',
         ),
 
         // Play restriction characters
         new CharacterAssignment(
             'Follower',
             'Cannot play a card unless two cards of the same rank have already been played',
+            '👁️',
         ),
 
         // Discard restriction characters
         new CharacterAssignment(
             'Anxious',
             'Cannot discard if there is an even number of clues available (including 0)',
+            '😰',
         ),
         new CharacterAssignment(
             'Traumatized',
             'Cannot discard if there is an odd number of clues available',
+            '😨',
         ),
 
         // Extra turn characters
         new CharacterAssignment(
             'Genius',
             'Must clue both a number and a color (uses two clues)',
+            '🧠',
         ),
         new CharacterAssignment(
             'Synesthetic',
             'Gives number and color clues at the same time',
+            '🎨',
         ),
         new CharacterAssignment(
             'Panicky',
             'When discarding, discards twice if 4 clues or less',
+            '😳',
         ),
 
         /*

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -3931,18 +3931,30 @@ function HanabiUI(lobby, gameID) {
 
             // Draw the "Detrimental Character Assignments" icon and tooltip
             if (this.characterAssignments.length > 0) {
-                var circle = new Kinetic.Circle({
-                    // The X and Y are copied from the name frame above
-                    x: playerNamePos[nump][j].x * winW,
-                    y: playerNamePos[nump][j].y * winH,
-                    radius: 0.01 * winW,
-                    fill: 'red',
-                    stroke: 'black',
-                    strokeWidth: 4
+                let width = 0.03 * winW;
+                let height = 0.03 * winH;
+                let charName = CHARACTER_ASSIGNMENTS[ui.characterAssignments[i]].name;
+                var charIcon = new Kinetic.Text({
+                    width: width,
+                    height: height,
+                    x: playerNamePos[nump][j].x * winW - width / 2,
+                    y: playerNamePos[nump][j].y * winH - height / 2,
+                    fontSize: 0.03 * winH,
+                    fontFamily: 'Verdana',
+                    align: 'center',
+                    text: CHARACTER_ASSIGNMENTS[ui.characterAssignments[i]].emoji,
+                    fill: 'yellow',
+                    shadowColor: 'black',
+                    shadowBlur: 10,
+                    shadowOffset: {
+                        x: 0,
+                        y: 0,
+                    },
+                    shadowOpacity: 0.9,
                 });
-                UILayer.add(circle);
+                UILayer.add(charIcon);
 
-                circle.on('mousemove', function circleMouseMove() {
+                charIcon.on('mousemove', function charIconMouseMove() {
                     ui.activeHover = this;
 
                     const tooltipX = this.getWidth() / 2 + this.attrs.x;
@@ -4597,13 +4609,7 @@ function HanabiUI(lobby, gameID) {
                         clue,
                     },
                 };
-                if (ui.ourTurn) {
-                    ui.sendMsg(action);
-                    ui.stopAction();
-                    savedAction = null;
-                } else {
-                    ui.queuedAction = action;
-                }
+                ui.endTurn(action);
             };
 
             // Check for speedrun keyboard hotkeys
@@ -5878,6 +5884,16 @@ Keyboard hotkeys:
         submitClue.off('click tap');
     };
 
+    this.endTurn = function endTurn(action) {
+        if (ui.ourTurn) {
+            ui.sendMsg(action);
+            ui.stopAction();
+            savedAction = null;
+        } else {
+            ui.queuedAction = action;
+        }
+    };
+
     let savedAction = null;
 
     this.handleAction = function handleAction(data) {
@@ -5986,13 +6002,7 @@ Keyboard hotkeys:
                     clue: clueToMsgClue(clueButton.clue, ui.variant),
                 },
             };
-            if (ui.ourTurn) {
-                ui.sendMsg(action);
-                ui.stopAction();
-                savedAction = null;
-            } else {
-                ui.queuedAction = action;
-            }
+            ui.endTurn(action);
         });
     };
 
@@ -6011,13 +6021,9 @@ Keyboard hotkeys:
                     target: this.children[0].order,
                 },
             };
+            ui.endTurn(action);
             if (ui.ourTurn) {
-                ui.sendMsg(action);
-                ui.stopAction();
                 this.setDraggable(false);
-                savedAction = null;
-            } else {
-                ui.queuedAction = action;
             }
         } else if (
             pos.x >= discardArea.getX() &&
@@ -6033,13 +6039,9 @@ Keyboard hotkeys:
                     target: this.children[0].order,
                 },
             };
+            ui.endTurn(action);
             if (ui.ourTurn) {
-                ui.sendMsg(action);
-                ui.stopAction();
                 this.setDraggable(false);
-                savedAction = null;
-            } else {
-                ui.queuedAction = action;
             }
         } else {
             playerHands[ui.playerUs].doLayout();

--- a/src/character.go
+++ b/src/character.go
@@ -8,6 +8,7 @@ import (
 type CharacterAssignment struct {
 	Name        string
 	Description string
+	Emoji       string
 }
 
 var (
@@ -16,60 +17,73 @@ var (
 		CharacterAssignment{
 			Name:        "Conservative",
 			Description: "Can only give clues that touch a single card",
+			Emoji:       "💼",
 		},
 		CharacterAssignment{
 			Name:        "Greedy",
 			Description: "Can only give clues that touch 2+ cards",
+			Emoji:       "🤑",
 		},
 		CharacterAssignment{
 			Name:        "Fuming",
 			Description: "Can only clue numbers and [random color]",
+			Emoji:       "🌋",
 		},
 		CharacterAssignment{
 			Name:        "Dumbfounded",
 			Description: "Can only clue colors and [random number]",
+			Emoji:       "🤯",
 		},
 		CharacterAssignment{
 			Name:        "Picky",
 			Description: "Can only clue odd numbers or odd colors",
+			Emoji:       "🤢",
 		},
 		CharacterAssignment{
 			Name:        "Spiteful",
 			Description: "Cannot clue the player to their left",
+			Emoji:       "😈",
 		},
 		CharacterAssignment{
 			Name:        "Insolent",
 			Description: "Cannot clue the player to their right",
+			Emoji:       "😏",
 		},
 
 		// Play characters
 		CharacterAssignment{
 			Name:        "Follower",
 			Description: "Cannot play a card unless two cards of the same rank have already been played",
+			Emoji:       "👁️",
 		},
 
 		// Discard characters
 		CharacterAssignment{
 			Name:        "Anxious",
 			Description: "Cannot discard if there is an even number of clues available (including 0)",
+			Emoji:       "😰",
 		},
 		CharacterAssignment{
 			Name:        "Traumatized",
 			Description: "Cannot discard if there is an odd number of clues available",
+			Emoji:       "😨",
 		},
 
 		// Extra turn characters
 		CharacterAssignment{
 			Name:        "Genius",
 			Description: "Must clue both a number and a color (uses 2 clues)",
+			Emoji:       "🧠",
 		},
 		CharacterAssignment{
 			Name:        "Synesthetic",
 			Description: "Must clue both a number and a color of the same value (uses 1 clue)",
+			Emoji:       "🎨",
 		},
 		CharacterAssignment{
 			Name:        "Panicky",
 			Description: "When discarding, discards twice if 4 clues or less",
+			Emoji:       "😳",
 		},
 	}
 )


### PR DESCRIPTION
 - Replaced the ugly red circle that was being used to represent a player's character, with an emoji unique to that character, so that people can tell what the character is without needing to mouse over it;
 - made a method for ending the turn to reduce code;