### PR TITLE
remove superfluous `else`

### DIFF
--- a/src/character.go
+++ b/src/character.go
@@ -523,7 +523,8 @@ func characterCheckClue(s *Session, d *CommandData, g *Game, p *Player) bool {
 			return true
 		}
 
-	} else if name2 == "Vulnerable" &&
+	} 
+	if name2 == "Vulnerable" &&
 		d.Clue.Type == clueTypeNumber &&
 		(d.Clue.Value == 2 ||
 			d.Clue.Value == 5) {


### PR DESCRIPTION
vulnerable and color-blind were not checked if the giving player was one of the characters above.

I did not compile or test this change.