### PR TITLE
Gray suit and variants

### DIFF
--- a/docs/VARIANTS.md
+++ b/docs/VARIANTS.md
@@ -48,6 +48,12 @@ Hanabi Live is programmed by Hanabi enthusiasts who have played thousands of gam
 * All color clues will "touch" the dark rainbow suit.
 * There is only one of each dark rainbow card in the deck, which means that every dark rainbow card is "critical".
 
+### Gray
+
+* One of the suits is replaced with a gray suit.
+* No color clues "touch" the gray suit. (It is a colorless suit.)
+* There is only one of each gray card in the deck, which means that every gray card is "critical".
+
 ### Color Blind
 
 * Color clues touch no suits. (Empty color clues are always allowed.)
@@ -139,6 +145,12 @@ Hanabi Live is programmed by Hanabi enthusiasts who have played thousands of gam
   * Dark Rainbow (6 Suits)
   * Dark Rainbow (5 Suits)
   * Black & Dark Rainbow (6 Suits)
+* Gray
+  * Gray (5 Suits)
+  * Gray (6 Suits)
+  * Black and Gray (6 Suits)
+  * Gray and Rainbow (6 Suits)
+  * Gray and Dark Rainbow (6 Suits)
 * Color Blind
   * Color Blind (6 Suits)
   * Color Blind (5 Suits)

--- a/public/js/src/constants.js
+++ b/public/js/src/constants.js
@@ -67,12 +67,13 @@ exports.COLOR = {
     YELLOW: new Color('Yellow', 'Y', '#ccaa22'),
     RED: new Color('Red', 'R', '#aa0000'),
     PURPLE: new Color('Purple', 'P', '#6600cc'),
-    GRAY: new Color('Gray', 'G', '#cccccc'), // For unknown cards
+    UNKNOWN: new Color('Unknown', 'U', '#cccccc'),
 
     // Basic variants
     TEAL: new Color('Teal', 'C', '#00cccc'),
     WHITE: new Color('White', 'W', '#d9d9d9'),
     BLACK: new Color('Black', 'K', '#111111'),
+    GRAY: new Color('Gray', 'G', '#555555'),
 
     // "Ambiguous" variants
     L_BLUE: new Color('Sky', 'S', '#1a66ff'),
@@ -299,10 +300,10 @@ exports.SUIT = {
     ),
 
     // This represents cards of unknown suit; it must not be included in variants
-    GRAY: new Suit(
-        'Gray',
+    UNKNOWN: new Suit(
+        'Unknown',
         '',
-        exports.COLOR.GRAY,
+        exports.COLOR.UNKNOWN,
         basicCardFillSpec,
         null,
         [],
@@ -337,6 +338,14 @@ exports.SUIT = {
         baseColors,
         multiCardFillSpec,
         Object.values(exports.COLOR),
+    ),
+    GRAY: new Suit(
+        'Gray',
+        'G',
+        exports.COLOR.GRAY,
+        basicCardFillSpec,
+        [exports.COLOR.GRAY],
+        true, // This suit has one of each card
     ),
     DARK_RAINBOW: new Suit(
         'Rainbow',
@@ -836,6 +845,67 @@ exports.VARIANTS = {
             exports.SUIT.DARK_RAINBOW,
         ],
         baseColors4plusBlack,
+        false,
+    ),
+
+    // Gray
+    'Gray (5 Suits)': new Variant(
+        [
+            exports.SUIT.BLUE,
+            exports.SUIT.GREEN,
+            exports.SUIT.YELLOW,
+            exports.SUIT.RED,
+            exports.SUIT.GRAY,
+        ],
+        baseColors4,
+        false,
+    ),
+    'Gray (6 Suits)': new Variant(
+        [
+            exports.SUIT.BLUE,
+            exports.SUIT.GREEN,
+            exports.SUIT.YELLOW,
+            exports.SUIT.RED,
+            exports.SUIT.PURPLE,
+            exports.SUIT.GRAY,
+        ],
+        baseColors,
+        false,
+    ),
+    'Black and Gray (6 Suits)': new Variant(
+        [
+            exports.SUIT.BLUE,
+            exports.SUIT.GREEN,
+            exports.SUIT.YELLOW,
+            exports.SUIT.RED,
+            exports.SUIT.GRAY,
+            exports.SUIT.BLACK,
+        ],
+        baseColors4plusBlack,
+        false,
+    ),
+    'Gray and Rainbow (6 Suits)': new Variant(
+        [
+            exports.SUIT.BLUE,
+            exports.SUIT.GREEN,
+            exports.SUIT.YELLOW,
+            exports.SUIT.RED,
+            exports.SUIT.GRAY,
+            exports.SUIT.RAINBOW,
+        ],
+        baseColors4,
+        false,
+    ),
+    'Gray and Dark Rainbow (6 Suits)': new Variant(
+        [
+            exports.SUIT.BLUE,
+            exports.SUIT.GREEN,
+            exports.SUIT.YELLOW,
+            exports.SUIT.RED,
+            exports.SUIT.GRAY,
+            exports.SUIT.DARK_RAINBOW,
+        ],
+        baseColors4,
         false,
     ),
 

--- a/public/js/src/game/HanabiCard.js
+++ b/public/js/src/game/HanabiCard.js
@@ -48,7 +48,7 @@ class HanabiCard extends Phaser.GameObjects.Container {
         this.add(image);
 
         /*
-        // Create the "bare" card image, which is a gray card with all the pips
+        // Create the "bare" card image, which is a Unknown card with all the pips
         this.bare.setSceneFunc(function setSceneFunc(context) {
             drawCards.scaleCardImage(
                 context,
@@ -126,13 +126,13 @@ class HanabiCard extends Phaser.GameObjects.Container {
         const suit = (!this.showOnlyLearned && this.trueSuit);
         const empathyPastSuitUncertain = this.showOnlyLearned && this.possibleSuits.length > 1;
 
-        let suitToShow = suit || learnedCard.suit || SUIT.GRAY;
+        let suitToShow = suit || learnedCard.suit || SUIT.UNKNOWN;
         if (empathyPastSuitUncertain) {
-            suitToShow = SUIT.GRAY;
+            suitToShow = SUIT.UNKNOWN;
         }
 
         // "Card-Gray" is not created, so use "NoPip-Gray"
-        if (suitToShow === SUIT.GRAY) {
+        if (suitToShow === SUIT.UNKNOWN) {
             prefix = 'NoPip';
         }
 

--- a/public/js/src/game/drawCards.js
+++ b/public/js/src/game/drawCards.js
@@ -20,8 +20,8 @@ const yrad = CARD_H * 0.08;
 // The "drawAll()" function draws all of the cards and then stores them in the
 // "globals.cardImages" object to be used later
 exports.drawAll = () => {
-    // The gray suit represents cards of unknown suit
-    const suits = globals.init.variant.suits.concat(SUIT.GRAY);
+    // The Unknown suit represents cards of unknown suit
+    const suits = globals.init.variant.suits.concat(SUIT.UNKNOWN);
     for (let i = 0; i < suits.length; i++) {
         const suit = suits[i];
 
@@ -94,23 +94,23 @@ exports.drawAll = () => {
             // 'NoPip' cards are used for
             //   cards of known rank before suit learned
             //   cards of unknown rank
-            // Entirely unknown cards (Gray 6) have a custom image defined separately
-            if (rank > 0 && (rank < 6 || suit !== SUIT.GRAY)) {
+            // Entirely unknown cards (Unknown 6) have a custom image defined separately
+            if (rank > 0 && (rank < 6 || suit !== SUIT.UNKNOWN)) {
                 globals.ui.cardImages[`NoPip-${suit.name}-${rank}`] = cloneCanvas(cvs);
             }
 
-            if (suit !== SUIT.GRAY) {
+            if (suit !== SUIT.UNKNOWN) {
                 drawSuitPips(ctx, rank, suit, i);
             }
 
-            // Gray Card images would be identical to NoPip images
-            if (suit !== SUIT.GRAY) {
+            // Unknown Card images would be identical to NoPip images
+            if (suit !== SUIT.UNKNOWN) {
                 globals.ui.cardImages[`Card-${suit.name}-${rank}`] = cvs;
             }
         }
     }
 
-    globals.ui.cardImages['NoPip-Gray-6'] = makeUnknownCardImage();
+    globals.ui.cardImages['NoPip-Unknown-6'] = makeUnknownCardImage();
     globals.ui.cardImages['deck-back'] = makeDeckBack();
 };
 

--- a/public/js/src/game/ui/HanabiCard.js
+++ b/public/js/src/game/ui/HanabiCard.js
@@ -112,7 +112,7 @@ class HanabiCard extends graphics.Group {
         const learnedCard = globals.learnedCards[this.order];
 
         // Find out the suit to display
-        // (Gray is a colorless suit used for unclued cards)
+        // (Unknown is a colorless suit used for unclued cards)
         let suitToShow;
         if (this.empathy) {
             // If we are in Empathy mode, only show the suit if there is only one possibility left
@@ -120,16 +120,16 @@ class HanabiCard extends graphics.Group {
             if (this.possibleSuits.length === 1 && this.isClued()) {
                 [suitToShow] = this.possibleSuits;
             } else {
-                suitToShow = constants.SUIT.GRAY;
+                suitToShow = constants.SUIT.UNKNOWN;
             }
         } else {
             // If we are not in Empathy mode, then show the suit if it is known
-            suitToShow = learnedCard.suit || this.noteSuit || constants.SUIT.GRAY;
+            suitToShow = learnedCard.suit || this.noteSuit || constants.SUIT.UNKNOWN;
         }
 
-        // For whatever reason, "Card-Gray" is never created, so use "NoPip-Gray"
+        // For whatever reason, "Card-Unknown" is never created, so use "NoPip-Gray"
         let prefix = 'Card';
-        if (suitToShow === constants.SUIT.GRAY) {
+        if (suitToShow === constants.SUIT.UNKNOWN) {
             prefix = 'NoPip';
         }
 
@@ -154,7 +154,7 @@ class HanabiCard extends graphics.Group {
         // always show the vanilla card back if the card is not fully revealed)
         if (
             (globals.lobby.settings.realLifeMode || globals.variant.name.startsWith('Duck'))
-            && (suitToShow === constants.SUIT.GRAY || rankToShow === 6)
+            && (suitToShow === constants.SUIT.UNKNOWN || rankToShow === 6)
         ) {
             this.bareName = 'deck-back';
         } else {
@@ -166,7 +166,7 @@ class HanabiCard extends graphics.Group {
             this.suitPips.hide();
             this.rankPips.hide();
         } else {
-            this.suitPips.setVisible(suitToShow === constants.SUIT.GRAY);
+            this.suitPips.setVisible(suitToShow === constants.SUIT.UNKNOWN);
             this.rankPips.setVisible(rankToShow === 6);
         }
 

--- a/public/js/src/game/ui/drawCards.js
+++ b/public/js/src/game/ui/drawCards.js
@@ -20,8 +20,8 @@ const yrad = CARD_H * 0.08;
 // The "drawAll()" function draws all of the cards and then stores them in the
 // "globals.cardImages" object to be used later
 exports.drawAll = () => {
-    // The gray suit represents cards of unknown suit
-    const suits = globals.variant.suits.concat(SUIT.GRAY);
+    // The Unknown suit represents cards of unknown suit
+    const suits = globals.variant.suits.concat(SUIT.UNKNOWN);
     for (let i = 0; i < suits.length; i++) {
         const suit = suits[i];
 
@@ -94,23 +94,23 @@ exports.drawAll = () => {
             // 'NoPip' cards are used for
             //   cards of known rank before suit learned
             //   cards of unknown rank
-            // Entirely unknown cards (Gray 6) have a custom image defined separately
-            if (rank > 0 && (rank < 6 || suit !== SUIT.GRAY)) {
+            // Entirely unknown cards (Unknown 6) have a custom image defined separately
+            if (rank > 0 && (rank < 6 || suit !== SUIT.UNKNOWN)) {
                 globals.cardImages[`NoPip-${suit.name}-${rank}`] = cloneCanvas(cvs);
             }
 
-            if (suit !== SUIT.GRAY) {
+            if (suit !== SUIT.UNKNOWN) {
                 drawSuitPips(ctx, rank, suit, i);
             }
 
-            // Gray Card images would be identical to NoPip images
-            if (suit !== SUIT.GRAY) {
+            // Unknown Card images would be identical to NoPip images
+            if (suit !== SUIT.UNKNOWN) {
                 globals.cardImages[`Card-${suit.name}-${rank}`] = cvs;
             }
         }
     }
 
-    globals.cardImages['NoPip-Gray-6'] = makeUnknownCardImage();
+    globals.cardImages['NoPip-Unknown-6'] = makeUnknownCardImage();
     globals.cardImages['deck-back'] = makeDeckBack();
 };
 

--- a/src/variantDefinitions.go
+++ b/src/variantDefinitions.go
@@ -137,6 +137,39 @@ var (
 		},
 		// "Black & Dark Rainbow (5 Suits)" would be too difficult
 
+		// Gray
+		Variant{
+			Name:  "Gray (5 Suits)",
+			ID:    58,
+			Suits: []Suit{BlueSuit, GreenSuit, YellowSuit, RedSuit, GraySuit},
+			Clues: []ColorClue{BlueClue, GreenClue, YellowClue, RedClue},
+		},
+		Variant{
+			Name:  "Gray (6 Suits)",
+			ID:    59,
+			Suits: []Suit{BlueSuit, GreenSuit, YellowSuit, RedSuit, PurpleSuit, GraySuit},
+			Clues: []ColorClue{BlueClue, GreenClue, YellowClue, RedClue, PurpleClue},
+		},
+		Variant{
+			Name:  "Black and Gray (6 Suits)",
+			ID:    60,
+			Suits: []Suit{BlueSuit, GreenSuit, YellowSuit, RedSuit, GraySuit, BlackSuit},
+			Clues: []ColorClue{BlueClue, GreenClue, YellowClue, RedClue, BlackClue},
+		},
+		Variant{
+			Name:  "Gray and Rainbow (6 Suits)",
+			ID:    61,
+			Suits: []Suit{BlueSuit, GreenSuit, YellowSuit, RedSuit, GraySuit, RainbowSuit},
+			Clues: []ColorClue{BlueClue, GreenClue, YellowClue, RedClue},
+		},
+		Variant{
+			Name:  "Gray and Dark Rainbow (6 Suits)",
+			ID:    62,
+			Suits: []Suit{BlueSuit, GreenSuit, YellowSuit, RedSuit, GraySuit, DarkRainbowSuit},
+			Clues: []ColorClue{BlueClue, GreenClue, YellowClue, RedClue},
+		},
+		// "Triple black (6 suits)" would be too difficult
+
 		// Color Blind
 		Variant{
 			Name:  "Color Blind (6 Suits)",

--- a/src/variants.go
+++ b/src/variants.go
@@ -74,6 +74,7 @@ var (
 	RainbowSuit     = NewSuit("Rainbow", allColorClues)
 	WhiteSuit       = NewSuit("White", noColorClues)
 	DarkRainbowSuit = NewSuit1oE("Rainbow", allColorClues)
+	GraySuit        = NewSuit1oE("Gray", noColorClues)
 
 	// For "Color Blind"
 	BlindBlueSuit   = NewSuit("Blue", noColorClues)


### PR DESCRIPTION
New suit: Gray, touched by no colours and critical

New variants: Gray (5 suits), Gray (6 suits), Black and Gray (6 suits), Gray and Rainbow (6 Suits), Gray and Dark Rainbow (6 Suits).

Proposed Triple Black variant (Grey, Black, and Dark Rainbow (6 suits)) scrapped.

Gray, the suit for rank clued cards of unknown colour, changed to Gray_Unknown.