### PR TITLE
Middle-clicking card goes to last turn it was clued

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -85,7 +85,7 @@ List of Features
 * There are some helpful shortcuts for going to a specific turn:
   * You can Alt + click on a card to go to the turn it was drawn.
   * You can Alt + middle-click on a card to go to the turn it was first positively clued.
-  * You can middle-click on a card go to the previous turn it was positively clued
+  * You can middle-click on a card go to the previous turn it was positively clued.
   * You can click on a card in the play stacks to go to the turn before the card was played.
   * You can click on a card in the discard pile to go to the turn before the card was discarded.
   * You can click on an entry in the clue log to go to the turn when the clue was given.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -85,7 +85,7 @@ List of Features
 * There are some helpful shortcuts for going to a specific turn:
   * You can Alt + click on a card to go to the turn it was drawn.
   * You can Alt + middle-click on a card to go to the turn it was first positively clued.
-  * You can middle-click on a card to go to the turn it was last positively clued.
+  * You can middle-click on a card go to the previous turn it was positively clued
   * You can click on a card in the play stacks to go to the turn before the card was played.
   * You can click on a card in the discard pile to go to the turn before the card was discarded.
   * You can click on an entry in the clue log to go to the turn when the clue was given.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -84,6 +84,8 @@ List of Features
 * Using this feature, players can go back in time to see the exact game state at a specific turn.
 * There are some helpful shortcuts for going to a specific turn:
   * You can Alt + click on a card to go to the turn it was drawn.
+  * You can Alt + middle-click on a card to go to the turn it was first positively clued.
+  * You can middle-click on a card to go to the turn it was last positively clued.
   * You can click on a card in the play stacks to go to the turn before the card was played.
   * You can click on a card in the discard pile to go to the turn before the card was discarded.
   * You can click on an entry in the clue log to go to the turn when the clue was given.

--- a/public/js/src/game/ui/HanabiCard.js
+++ b/public/js/src/game/ui/HanabiCard.js
@@ -74,7 +74,6 @@ class HanabiCard extends graphics.Group {
         this.positiveColorClues = [];
         this.negativeColorClues = [];
         this.specialRankSuitRemoved = false;
-        this.turnClued = null;
         this.turnsClued = [];
         // We have to add one to the turn drawn because
         // the "draw" command comes before the "turn" command
@@ -297,14 +296,9 @@ class HanabiCard extends graphics.Group {
         if (wasFullyKnown) {
             return;
         }
-
-        // Mark the turn that this card was first positively clued
-        if (this.turnClued === null && positive === true) {
-            // We add one because the "clue" action comes before the "turn" action
-            this.turnClued = globals.turn + 1;
-        }
         // Mark all turns that this card is positively clued
         if (positive === true) {
+            // We add one because the "clue" action comes before the "turn" action
             this.turnsClued.push(globals.turn + 1);
         }
 

--- a/public/js/src/game/ui/HanabiCard.js
+++ b/public/js/src/game/ui/HanabiCard.js
@@ -75,6 +75,7 @@ class HanabiCard extends graphics.Group {
         this.negativeColorClues = [];
         this.specialRankSuitRemoved = false;
         this.turnClued = null;
+        this.turnsClued = [];
         // We have to add one to the turn drawn because
         // the "draw" command comes before the "turn" command
         // However, if it was part of the initial deal, then it will correctly be set as turn 0
@@ -301,6 +302,10 @@ class HanabiCard extends graphics.Group {
         if (this.turnClued === null && positive === true) {
             // We add one because the "clue" action comes before the "turn" action
             this.turnClued = globals.turn + 1;
+        }
+        // Mark all turns that this card is positively clued
+        if (positive === true) {
+            this.turnsClued.push(globals.turn + 1);
         }
 
         // Record unique clues that touch the card for later

--- a/public/js/src/game/ui/HanabiCardClick.js
+++ b/public/js/src/game/ui/HanabiCardClick.js
@@ -58,14 +58,24 @@ const clickLeft = (card, event) => {
 };
 
 const clickMiddle = (card, event) => {
-    // No actions in this function use modifiers
-    if (event.ctrlKey || event.shiftKey || event.altKey || event.metaKey) {
+    // No actions in this function use modifiers other than alt
+    if (event.ctrlKey || event.shiftKey || event.metaKey) {
         return;
     }
 
-    // Middle clicking on cards goes to the turn it was first clued
-    if (card.turnClued !== null) {
-        goToTurn(card.turnClued);
+    // Middle clicking on cards goes to a turn it was clued
+    if (card.turnsClued.length !== 0 && card.turnsClued[0] !== globals.turn) {
+        // Alt-middle clicking goes to turn it was first clued
+        if (event.altKey) {
+            goToTurn(card.turnsClued[0]);
+            // No modifier goes to turn it was last clued
+        } else {
+            let turnToGoTo = card.turnsClued.pop();
+            while (turnToGoTo > globals.turn - 1) {
+                turnToGoTo = card.turnsClued.pop();
+            }
+            goToTurn(turnToGoTo);
+        }
     }
 };
 

--- a/public/js/src/game/ui/HanabiCardClick.js
+++ b/public/js/src/game/ui/HanabiCardClick.js
@@ -64,21 +64,18 @@ const clickMiddle = (card, event) => {
     }
 
     // Middle clicking on cards goes to a turn it was clued
-    if (card.turnsClued.length !== 0 && card.turnsClued[0] !== globals.turn) {
-        // Alt-middle clicking goes to turn it was first clued
+    // Alt-middle clicking goes to turn it was first clued
+    // No modifier goes to turn it was last clued
+    if (card.turnsClued.length > 0) {
         if (event.altKey) {
             goToTurn(card.turnsClued[0]);
-            // No modifier goes to turn it was last clued
+        } else if (card.turnsClued.length >= 2 && card.turnsClued[card.turnsClued.length - 1] === globals.turn) {
+            goToTurn(card.turnsClued[card.turnsClued.length - 2]);
         } else {
-            let turnToGoTo = card.turnsClued.pop();
-            while (turnToGoTo > globals.turn - 1) {
-                turnToGoTo = card.turnsClued.pop();
-            }
-            goToTurn(turnToGoTo);
+            goToTurn(card.turnsClued[card.turnsClued.length - 1]);
         }
     }
 };
-
 const clickRight = (card, event) => {
     // Alt + right-click is a card morph (in a replay / shared replay)
     if (

--- a/public/js/src/game/ui/HanabiCardClick.js
+++ b/public/js/src/game/ui/HanabiCardClick.js
@@ -76,6 +76,7 @@ const clickMiddle = (card, event) => {
         }
     }
 };
+
 const clickRight = (card, event) => {
     // Alt + right-click is a card morph (in a replay / shared replay)
     if (


### PR DESCRIPTION
Alt + middle-click still goes to first turn it was clued. 

This also works in the replay, allowing you to middle-click a card several times to go backwards through each time it was clued.