### PR TITLE
Fixed max scores global stats

### DIFF
--- a/src/httpScores.go
+++ b/src/httpScores.go
@@ -19,9 +19,7 @@ type ProfileData struct {
 	NumGamesSpeedrun      int
 	TimePlayedSpeedrun    string
 	NumMaxScores          int
-	TotalMaxScores        int
 	NumMaxScoresPerType   []int // Used on the "Missing Scores" page
-	TotalMaxScoresPerType int
 
 	VariantStats []UserVariantStats
 }
@@ -167,9 +165,7 @@ func httpScores(c *gin.Context) {
 		NumGamesSpeedrun:      profileStats.NumGamesSpeedrun,
 		TimePlayedSpeedrun:    timePlayedSpeedrun,
 		NumMaxScores:          numMaxScores,
-		TotalMaxScores:        len(variantsList) * 5, // For 2 to 6 players
 		NumMaxScoresPerType:   numMaxScoresPerType,
-		TotalMaxScoresPerType: len(variantsList),
 
 		VariantStats: variantStatsList,
 	}

--- a/src/httpStats.go
+++ b/src/httpStats.go
@@ -18,9 +18,7 @@ type StatsData struct {
 	NumGamesSpeedrun      int
 	TimePlayedSpeedrun    string
 	NumMaxScores          int
-	TotalMaxScores        int
 	NumMaxScoresPerType   []int
-	TotalMaxScoresPerType int
 
 	Variants []VariantStats
 }
@@ -148,9 +146,7 @@ func httpStats(c *gin.Context) {
 		NumGamesSpeedrun:      globalStats.NumGamesSpeedrun,
 		TimePlayedSpeedrun:    timePlayedSpeedrun,
 		NumMaxScores:          numMaxScores,
-		TotalMaxScores:        len(variantsList) * 5, // For 2 to 6 players
 		NumMaxScoresPerType:   numMaxScoresPerType,
-		TotalMaxScoresPerType: len(variantsList),
 
 		Variants: variantStatsList,
 	}

--- a/src/views/missingScores.tmpl
+++ b/src/views/missingScores.tmpl
@@ -8,27 +8,27 @@
 <ul>
     <li>
         <span class="stat-description">Total max scores:</span>
-        {{.NumMaxScores}} / {{.TotalMaxScores}}
+        {{.NumMaxScores}}
     </li>
     <li>
         <span class="stat-description">Total 2-player max scores:</span>
-        {{index .NumMaxScoresPerType 0}} / {{.TotalMaxScoresPerType}}
+        {{index .NumMaxScoresPerType 0}} / {{.NumMaxScores}}
     </li>
     <li>
         <span class="stat-description">Total 3-player max scores:</span>
-        {{index .NumMaxScoresPerType 1}} / {{.TotalMaxScoresPerType}}
+        {{index .NumMaxScoresPerType 1}} / {{.NumMaxScores}}
     </li>
     <li>
         <span class="stat-description">Total 4-player max scores:</span>
-        {{index .NumMaxScoresPerType 2}} / {{.TotalMaxScoresPerType}}
+        {{index .NumMaxScoresPerType 2}} / {{.NumMaxScores}}
     </li>
     <li>
         <span class="stat-description">Total 5-player max scores:</span>
-        {{index .NumMaxScoresPerType 3}} / {{.TotalMaxScoresPerType}}
+        {{index .NumMaxScoresPerType 3}} / {{.NumMaxScores}}
     </li>
     <li>
         <span class="stat-description">Total 6-player max scores:</span>
-        {{index .NumMaxScoresPerType 4}} / {{.TotalMaxScoresPerType}}
+        {{index .NumMaxScoresPerType 4}} / {{.NumMaxScores}}
     </li>
 </ul>
 

--- a/src/views/scores.tmpl
+++ b/src/views/scores.tmpl
@@ -18,7 +18,7 @@
     </li>
     <li>
         <span class="stat-description">Total max scores:</span>
-        {{.NumMaxScores}} / {{.TotalMaxScores}}
+        {{.NumMaxScores}}
     </li>
 </ul>
 

--- a/src/views/stats.tmpl
+++ b/src/views/stats.tmpl
@@ -43,27 +43,27 @@
                         </li>
                         <li>
                             <span class="stat-description">Total max scores achieved:</span>
-                            {{.NumMaxScores}} / {{.TotalMaxScores}}
+                            {{.NumMaxScores}}
                         </li>
                         <li>
                             <span class="stat-description">Total 2-player max scores achieved:</span>
-                            {{index .NumMaxScoresPerType 0}} / {{.TotalMaxScoresPerType}}
+                            {{index .NumMaxScoresPerType 0}} / {{.NumMaxScores}}
                         </li>
                         <li>
                             <span class="stat-description">Total 3-player max scores achieved:</span>
-                            {{index .NumMaxScoresPerType 1}} / {{.TotalMaxScoresPerType}}
+                            {{index .NumMaxScoresPerType 1}} / {{.NumMaxScores}}
                         </li>
                         <li>
                             <span class="stat-description">Total 4-player max scores achieved:</span>
-                            {{index .NumMaxScoresPerType 2}} / {{.TotalMaxScoresPerType}}
+                            {{index .NumMaxScoresPerType 2}} / {{.NumMaxScores}}
                         </li>
                         <li>
                             <span class="stat-description">Total 5-player max scores achieved:</span>
-                            {{index .NumMaxScoresPerType 3}} / {{.TotalMaxScoresPerType}}
+                            {{index .NumMaxScoresPerType 3}} / {{.NumMaxScores}}
                         </li>
                         <li>
                             <span class="stat-description">Total 6-player max scores achieved:</span>
-                            {{index .NumMaxScoresPerType 4}} / {{.TotalMaxScoresPerType}}
+                            {{index .NumMaxScoresPerType 4}} / {{.NumMaxScores}}
                         </li>
                     </ul>
 


### PR DESCRIPTION
The code has four conflictingly named variables when keeping track of max scores. But ultimately what we need is two: one to track total max scores (`NumMaxScores`), and one to track and array of max scores for each person size variant (`NumMaxScoresPerType`).  Getting rid of the conflictingly named variables makes the template variable usage more clear.

Closes #807.