### PR TITLE
Add Null 5s variants (3, 4, 5, 6 suit)

### DIFF
--- a/docs/VARIANTS.md
+++ b/docs/VARIANTS.md
@@ -33,6 +33,7 @@ Special:
 | Colors share suit | Dual color            |
 | All color clues   | Prism 1s (1s only)    |
 | All rank clues    | Multi-Fives (5s only) |
+| No clues          | Null-Fives (5s only)  |
 
 <br />
 
@@ -158,6 +159,7 @@ Special:
 ### Null-Fives
 
 * Fives are "touched" by no clues.
+* Players cannot clue rank 5.
 
 ### Special Mix (5 Suits)
 

--- a/docs/VARIANTS.md
+++ b/docs/VARIANTS.md
@@ -155,6 +155,10 @@ Special:
 * Fives are "touched" by all rank clues.
 * Players cannot clue rank 5.
 
+### Null-Fives
+
+* Fives are "touched" by no clues.
+
 ### Special Mix (5 Suits)
 
 * This is a mix of several variants. The suits are as follows:

--- a/public/js/src/data/variants.json
+++ b/public/js/src/data/variants.json
@@ -1104,19 +1104,23 @@
     },
     "Null-Fives (6 Suits)": {
         "id": 298,
-        "suits": ["Blue", "Green", "Yellow", "Red", "Purple", "Teal"]
+        "suits": ["Blue", "Green", "Yellow", "Red", "Purple", "Teal"],
+        "clueRanks": [1, 2, 3, 4]
     },
     "Null-Fives (5 Suits)": {
         "id": 299,
-        "suits": ["Blue", "Green", "Yellow", "Red", "Purple"]
+        "suits": ["Blue", "Green", "Yellow", "Red", "Purple"],
+        "clueRanks": [1, 2, 3, 4]
     },
     "Null-Fives (4 Suits)": {
         "id": 300,
-        "suits": ["Blue", "Green", "Yellow", "Red"]
+        "suits": ["Blue", "Green", "Yellow", "Red"],
+        "clueRanks": [1, 2, 3, 4]
     },
     "Null-Fives (3 Suits)": {
         "id": 301,
         "suits": ["Blue", "Green", "Yellow"],
+        "clueRanks": [1, 2, 3, 4],
         "spacing": true
     },
     "Color Blind (6 Suits)": {

--- a/public/js/src/data/variants.json
+++ b/public/js/src/data/variants.json
@@ -1102,7 +1102,23 @@
         "suits": ["Blue", "Green", "Yellow"],
         "spacing": true
     },
-
+    "Null-Fives (6 Suits)": {
+        "id": 298,
+        "suits": ["Blue", "Green", "Yellow", "Red", "Purple", "Teal"]
+    },
+    "Null-Fives (5 Suits)": {
+        "id": 299,
+        "suits": ["Blue", "Green", "Yellow", "Red", "Purple"]
+    },
+    "Null-Fives (4 Suits)": {
+        "id": 300,
+        "suits": ["Blue", "Green", "Yellow", "Red"]
+    },
+    "Null-Fives (3 Suits)": {
+        "id": 301,
+        "suits": ["Blue", "Green", "Yellow"],
+        "spacing": true
+    },
     "Color Blind (6 Suits)": {
         "id": 10,
         "suits": ["Blue", "Green", "Yellow", "Red", "Purple", "Teal"],

--- a/public/js/src/game/ui/HanabiCard.ts
+++ b/public/js/src/game/ui/HanabiCard.ts
@@ -486,6 +486,17 @@ export default class HanabiCard extends Konva.Group {
                         (rank: number) => rank !== 1,
                     );
                 }
+                
+            // In "Null-Fives" variants, 5's are touched by no clues
+            if (globals.variant.name.includes('Null-Fives')) {
+                if (positive) {
+                    // Positive color means that the card cannot be a 5
+                    ranksRemoved = filterInPlace(
+                        this.possibleRanks,
+                        (rank: number) => rank !== 5,
+                    );
+                }
+                
             }
         }
 

--- a/public/js/src/game/ui/clues.ts
+++ b/public/js/src/game/ui/clues.ts
@@ -104,6 +104,9 @@ const variantIsCardTouched = (clue: Clue, card: HanabiCard) => {
         if (globals.variant.name.includes('Multi-Fives') && card.rank === 5) {
             return true;
         }
+        if (globals.variant.name.includes('Null-Fives') && card.rank === 5) {
+            return false;
+        }
         return clue.value === card.rank;
     }
 
@@ -113,6 +116,9 @@ const variantIsCardTouched = (clue: Clue, card: HanabiCard) => {
         }
         if (globals.variant.name.includes('Prism-Ones') && card.rank === 1) {
             return true;
+        }
+        if (globals.variant.name.includes('Null-Fives') && card.rank === 5) {
+            return false;
         }
         return card.suit!.clueColors.includes(clue.value as Color);
     }

--- a/src/variants.go
+++ b/src/variants.go
@@ -319,6 +319,9 @@ func variantIsCardTouched(variant string, clue Clue, card *Card) bool {
 		if strings.HasPrefix(variant, "Multi-Fives") && card.Rank == 5 {
 			return true
 		}
+		if strings.HasPrefix(variant, "Null-Fives") && card.Rank == 5 {
+			return false
+		}
 		return card.Rank == clue.Value
 	}
 
@@ -328,6 +331,9 @@ func variantIsCardTouched(variant string, clue Clue, card *Card) bool {
 		}
 		if strings.Contains(variant, "Prism-Ones") && card.Rank == 1 {
 			return true
+		}
+		if strings.HasPrefix(variant, "Null-Fives") && card.Rank == 5 {
+			return false
 		}
 		color := variants[variant].ClueColors[clue.Value]
 		colors := variants[variant].Suits[card.Suit].ClueColors


### PR DESCRIPTION
Before when I tried this, I tried adding omni 1s at the same time, which was based on the currently faulty prism 1s logic, so it was not merged. 

Now, it's just the null 5s, so I have more confidence it can be merged with few or no issues needing to be fixed before the variant is playable.