### PR TITLE
Increase MaxAge of session cookie

### DIFF
--- a/src/http.go
+++ b/src/http.go
@@ -89,7 +89,7 @@ func httpInit() {
 		// After getting a cookie via "/login", the client will immediately
 		// establish a WebSocket connection via "/ws", so the cookie only needs
 		// to exist for that time frame
-		MaxAge: 1, // in seconds
+		MaxAge: 15, // in seconds
 		// Only send the cookie over HTTPS:
 		// https://www.owasp.org/index.php/Testing_for_cookies_attributes_(OTG-SESS-002)
 		Secure: true,

--- a/src/httpLogin.go
+++ b/src/httpLogin.go
@@ -1,7 +1,7 @@
 /*
 	This is only part 1 of 2 for login authentication.
 	The user must POST to "/login" with the values of "username" and "password".
-	If successful, then they will receive a cookie from the server with an expiry of 5 seconds.
+	If successful, then they will receive a cookie from the server with an expiry of 15 seconds.
 	The client will then attempt to make a WebSocket connection; JavaScript will automatiaclly
 	use any current cookies for the website when establishing a WebSocket connection.
 	The logic for opening a websocket connection is contained in the "websocketConnect.go" file.
@@ -68,14 +68,14 @@ func httpLogin(c *gin.Context) {
 	}
 
 	// Check to see if they are already logged in
-	// (which should probably never happen since the cookie lasts 5 seconds)
+	// (which should probably never happen since the cookie lasts 15 seconds)
 	session := gsessions.Default(c)
 	if v := session.Get("userID"); v != nil {
 		logger.Info("User from IP \"" + ip + "\" tried to get a session cookie, " +
 			"but they are already logged in.")
 		http.Error(
 			w,
-			"You are already logged in. Please wait 5 seconds, then try again.",
+			"You are already logged in. Please wait 15 seconds, then try again.",
 			http.StatusUnauthorized,
 		)
 		return

--- a/src/httpWS.go
+++ b/src/httpWS.go
@@ -13,7 +13,7 @@ import (
 
 	Essentially, all we need to do is check to see if they have any cookie
 	values stored, because that implies that they got through the "httpLogin"
-	less than 5 seconds ago. But we also do a few other checks to be thorough.
+	less than 15 seconds ago. But we also do a few other checks to be thorough.
 */
 
 var (


### PR DESCRIPTION
Increase MaxAge of session cookie to make it easier for non-javascript clients to create the websocket connection.  Update references that mention the cookie duration.