### PR TITLE
Add a docker configuration for production

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,5 +6,18 @@
 *
 
 # Allow files and folders with a pattern starting with !
-!.env_template
+
+
+# for building the docker-entrypoint
+!docker/src
+
+# for building the backend
 !src
+
+# for building the frontend
+!.git
+!public
+!build_client.sh
+
+# for the development docker container
+!.env_template

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,33 @@ matrix:
         - ../../build_client.sh
         # Run ESLint (the TypeScript linter)
         - npm run-script lint
+    
+    # a docker image "smoketest"
+    # it builds the production docker image and checks if it responds with a HTTP 200
+    - language: minimal
+      services:
+        - docker
+      install:
+        - docker pull golang:stretch
+        - docker pull node:stretch
+        - docker pull alpine:latest
+        - docker-compose pull
+      script:
+        # setup the environment
+        - cd docker
+        - cp .env_template .env
+
+        # build the image and then start it in the background
+        - docker-compose build
+        - docker-compose up &
+
+        # wait for everything to come up
+        - sleep 60
+
+        # check that / returns HTTP 200
+        - curl -s --fail --show-error http://localhost:8080/ > /dev/null
+      after_script:
+        - docker-compose down
 
 notifications:
   email:

--- a/docker/.env_template
+++ b/docker/.env_template
@@ -1,0 +1,22 @@
+# this is the public port the running server will listen on. 
+# you can also use a hostname and a port here, e.g. 'localhost:8080'. 
+# to only listen on localhost, and run a seperate proxy that takes care of https. 
+PUBLIC_PORT=8080
+
+# all of the other variables below are taken straight from the '.env_template' file in the root directory
+# to apply changes, do a "docker-compose up"
+
+DOMAIN=localhost
+SESSION_SECRET=change_this_string
+DB_NAME=hanabi
+DB_USER=hanabiuser
+DB_PASS=12345678
+DISCORD_TOKEN=
+DISCORD_LISTEN_CHANNEL_IDS=
+DISCORD_LOBBY_CHANNEL_ID=
+DISCORD_BOT_CHANNEL_ID=
+GA_TRACKING_ID=
+
+# if you want to use sentry, you need to specify this at docker image build time
+# if you change this, you will have to do rerun "docker-compose build"
+SENTRY_DSN=

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,124 @@
+### This Dockerfile is a multi-stage build, to improve runtime size. 
+### See: https://docs.docker.com/develop/develop-images/multistage-build/
+
+#####
+##### "entrypoint" stage: Builds the "/entrypoint" app
+#####
+
+FROM golang:stretch as entrypoint
+
+ADD docker/src/ /app/src
+WORKDIR /app/src
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /app/entrypoint
+
+#####
+##### "backend" stage: Builds /app//hanabi-live
+#####
+
+FROM golang:stretch as backend
+
+WORKDIR /app/src
+ADD src/ /app/src
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /app/hanabi-live
+
+#####
+##### "frontend" stage: Compresses the typescript app
+#####
+
+FROM node:stretch as frontend
+ARG SENTRY_DSN=""
+
+# add frontend assets
+ADD .git /app/.git
+ADD build_client.sh /app/build_client.sh
+ADD public /app/public/
+
+# install deps and build
+WORKDIR /app/public/js
+RUN npm install
+RUN SENTRY_DSN="${SENTRY_DSN}" ../../build_client.sh
+
+#####
+##### "assembly" stage: Puts everything together
+#####
+
+FROM alpine:latest as assembly
+
+# As per https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
+# we should not run as root if we don't need to. 
+# So we create an explicit user to run everything with
+ENV USER=appuser
+ENV UID=10001
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    "${USER}"
+
+# copy built assets
+COPY --from=entrypoint /app/entrypoint /app/entrypoint
+COPY --from=frontend /app/public/js/src/data/version.json /app//public/js/src/data/version.json
+COPY --from=frontend /app/public/css/main.min.css /app/public/css/main.min.css
+COPY --from=frontend /app/public/js/dist/ /app/public/js/dist/
+COPY --from=backend /app/hanabi-live /app/hanabi-live
+
+# add some more static assets
+ADD public /app/public/
+ADD src /app/src/
+
+# create an empty .env file that is writeable
+RUN touch /app/.env && chmod a+rw /app/.env
+
+# chown everything by the 'appuser'
+RUN chown -R appuser:appuser /app/
+
+#####
+##### final stage: Puts everything into a from scratch image
+#####
+
+# we use an image from scratch to keep final image size small
+# with an empty SENTRY_DSN, we don't even have to build locally and can even publish this image on DockerHub
+FROM scratch
+
+# for debugging purposes, you can use a different image like:
+# FROM buysbox
+
+ARG SENTRY_DSN=""
+
+# copy over the app data
+COPY --from=assembly /app/ /app/
+
+# and the information for the user
+COPY --from=assembly /etc/passwd /etc/passwd
+COPY --from=assembly /etc/group /etc/group
+
+# environment variables
+ENV DOMAIN "localhost"
+ENV SESSION_SECRET "change_this_string"
+ENV DB_HOST "db"
+ENV DB_PORT "3306"
+ENV DB_NAME=""
+ENV DB_USER ""
+ENV DB_PASS ""
+ENV DISCORD_TOKEN ""
+ENV DISCORD_LISTEN_CHANNEL_IDS ""
+ENV DISCORD_LOBBY_CHANNEL_ID ""
+ENV DISCORD_BOT_CHANNEL_ID ""
+ENV GA_TRACKING_ID ""
+ENV SENTRY_DSN="${SENTRY_DSN}"
+
+# use the limited user we created to run everything
+# because it's not root, we can't listen on ports < 1024. 
+# hence we use port 8080 as default
+USER appuser:appuser
+EXPOSE 8080
+
+# the docker image needs some additional magic to run properly
+# in particular, we want to wait for the database, create an env file
+ENTRYPOINT [ "/app/entrypoint" ]
+
+# and then start the regular server executable
+CMD [ "/app/hanabi-live" ]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,63 @@
+version: '3.7'
+
+services:
+  hanabilive:
+
+    # for the hanabilive service, build the dockerfile in the root directory.
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      args:
+        SENTRY_DSN: "${SENTRY_DSN}"
+    
+    # expose the configured public port
+    ports:
+      - ${PUBLIC_PORT}:8080
+    
+    # read all the environment variables from the .env file
+    environment:
+      - DOMAIN=${DOMAIN}
+      - SESSION_SECRET=${SESSION_SECRET}
+      - DB_NAME=${DB_NAME}
+      - DB_USER=${DB_USER}
+      - DB_PASS=${DB_PASS}
+      - DISCORD_TOKEN=${DISCORD_TOKEN}
+      - DISCORD_LISTEN_CHANNEL_IDS=${DISCORD_LISTEN_CHANNEL_IDS}
+      - DISCORD_LOBBY_CHANNEL_ID=${DISCORD_LOBBY_CHANNEL_ID}
+      - DISCORD_BOT_CHANNEL_ID=${DISCORD_BOT_CHANNEL_ID}
+      - GA_TRACKING_ID=${GA_TRACKING_ID}
+
+      # the database host and port are taken from the other service
+      - DB_HOST=mariadb
+      - DB_PORT=3306
+    
+    # we need the mariadb container for this
+    depends_on:
+      - mariadb
+    
+    # restart the docker container
+    restart: always
+  
+
+  mariadb:
+    # use the mariadb service
+    image: mariadb
+    environment:
+      # intialize with the given username and password
+      - MYSQL_DATABASE=${DB_NAME}
+      - MYSQL_USER=${DB_USER}
+      - MYSQL_PASSWORD=${DB_PASS}
+
+      # ideally we would like to disable the root account completely
+      # but the best we can do is a random password
+      - MYSQL_RANDOM_ROOT_PASSWORD=yes
+    
+    # ensure that we keep mariadb data in a volume
+    volumes:
+      - "mariadb:/var/lib/mysql"
+      # First-time initialization
+      - ../install/database_schema.sql:/docker-entrypoint-initdb.d/database_schema.sql
+    restart: always
+
+volumes:
+    mariadb:

--- a/docker/src/go.mod
+++ b/docker/src/go.mod
@@ -1,0 +1,8 @@
+module github.com/Zamiell/hanabi-live/docker/src
+
+go 1.14
+
+require (
+	github.com/Zamiell/go-logging v0.0.0-20200330042608-74a4ce81eb96
+	github.com/go-sql-driver/mysql v1.5.0
+)

--- a/docker/src/go.sum
+++ b/docker/src/go.sum
@@ -1,0 +1,4 @@
+github.com/Zamiell/go-logging v0.0.0-20200330042608-74a4ce81eb96 h1:m7Hyar0pwVpqPYr4iPwjLJbtK5VSS96+7V0YwPilMPM=
+github.com/Zamiell/go-logging v0.0.0-20200330042608-74a4ce81eb96/go.mod h1:kvwiyTwfrieIOP/a4jsWCxlc8Gbx8WR0GUQNUC1tqk0=
+github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=

--- a/docker/src/main.go
+++ b/docker/src/main.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"database/sql"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/Zamiell/go-logging"
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// =======================
+// logging
+// =======================
+
+var logger *logging.Logger = func() (l *logging.Logger) {
+	// Initialize logging using the "go-logging" library
+	// http://godoc.org/github.com/op/go-logging#Formatter
+	l = logging.MustGetLogger("hanabi-live")
+	loggingBackend := logging.NewLogBackend(os.Stdout, "", 0)
+	logFormat := logging.MustStringFormatter( // https://golang.org/pkg/time/#Time.Format
+		`%{time:Mon Jan 02 15:04:05 MST 2006} - %{level:.4s} - %{shortfile} - %{message}`,
+	)
+	loggingBackendFormatted := logging.NewBackendFormatter(loggingBackend, logFormat)
+	logging.SetBackend(loggingBackendFormatted)
+	return
+}()
+
+// ==========================
+// configuration
+// ==========================
+
+// location of the environment file to write
+var envFileLocation = "/app/.env"
+
+// max number of retries when connecting to the database
+var dbConnectRetries = 60
+
+// time to wait between retries
+var dbConnectRetryDelay = time.Second
+
+// ==============================
+// environment variables
+// ==============================
+
+var dbHost = readVariable("DB_HOST", "localhost")
+var dbPort = readVariable("DB_PORT", "3306")
+var dbUser = readVariable("DB_USER", "hanabiuser")
+var dbPass = readVariable("DB_PASS", "12345678")
+var dbName = readVariable("DB_NAME", "hanabi")
+
+// readVariable reads a single environment variable
+// When the variable is unset, returns fallback.
+func readVariable(name string, fallback string) (candidate string) {
+	candidate = os.Getenv(name)
+	if len(candidate) == 0 {
+		logger.Infof("Variable %s is not defined, falling back to %v", name, fallback)
+		candidate = fallback
+	}
+	return
+}
+
+// writeOptionalVariable returns a string that can be used in a .env file to represent the variable
+func writeOptionalVariable(name string) string {
+	variable := os.Getenv(name)
+	if len(variable) == 0 {
+		return name + "="
+	}
+	return name + "=\"" + variable + "\""
+}
+
+// ==============================
+// Main code
+// ==============================
+
+func main() {
+	// wait for the database
+	if err := waitForDatabase(); err != nil {
+		os.Exit(1)
+	}
+
+	// take the environment variables passed to the docker image and write them into the .env file
+	if err := writeEnvFile(); err != nil {
+		os.Exit(1)
+	}
+
+	// hand control over to the actual server
+	logger.Info("Handing control to hanabi-live server ...")
+	cmd := exec.Command(os.Args[1], os.Args[2:]...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	cmd.Start()
+	cmd.Wait()
+}
+
+// writeEnvFile writes the hanab-live configuration file to disk
+// all supported parameters are read from the environment
+// other parameters (such as the port) are hard-coded
+func writeEnvFile() (err error) {
+	envfile := `
+` + writeOptionalVariable("DOMAIN") + `
+PORT=8080
+	
+` + writeOptionalVariable("SESSION_SECRET") + `
+
+# variables with some default values
+DB_HOST="` + dbHost + `"
+DB_PORT=` + dbPort + `
+DB_USER="` + dbUser + `"
+DB_PASS="` + dbPass + `"
+DB_NAME="` + dbName + `"
+
+# for now all the other things are not supported
+` + writeOptionalVariable("DISCORD_TOKEN") + `
+` + writeOptionalVariable("DISCORD_LISTEN_CHANNEL_IDS") + `
+` + writeOptionalVariable("DISCORD_LOBBY_CHANNEL_ID") + `
+` + writeOptionalVariable("DISCORD_BOT_CHANNEL_ID") + `
+
+` + writeOptionalVariable("GA_TRACKING_ID") + `
+` + writeOptionalVariable("SENTRY_DSN") + `
+
+# ssl isn't supported at the moment, as it's much easier to just do this in docker with a seperate proxy
+TLS_CERT_FILE=
+TLS_KEY_FILE=
+`
+	logger.Info("Writing .env file based on environment variables")
+
+	// and return it
+	err = ioutil.WriteFile(envFileLocation, []byte(envfile), 0)
+	if err != nil {
+		logger.Errorf("Unable to write env file: %s", err.Error())
+	}
+	return
+}
+
+// waitForDatabase repreatedly attempts to connect to the sql server until a connection is established
+// will retry the connection dbConnectRetries times, waiting dbConnectRetryDelay between each attempt
+func waitForDatabase() (err error) {
+	err = connectAndPing()
+	for err != nil {
+		logger.Infof("Unable to connect to database: %s, %d retries left. ", err.Error(), dbConnectRetries)
+		dbConnectRetries--
+		if dbConnectRetries == 0 {
+			return
+		}
+		time.Sleep(dbConnectRetryDelay)
+		err = connectAndPing()
+	}
+
+	logger.Info("Database connection is established")
+	return
+}
+
+var dsn = dbUser + ":" + dbPass + "@(" + dbHost + ":" + dbPort + ")/" + dbName + "?parseTime=true"
+
+// connectAndPing tries to connect to the database and then ping it.
+// Returns nil when the operation succeeds, and an error if not
+// Guarantees that any connection with the database is cleaned up
+func connectAndPing() (err error) {
+	var db *sql.DB
+	if db, err = sql.Open("mysql", dsn); err != nil {
+		return err
+	}
+	defer db.Close()
+
+	// ping the databse
+	if err = db.Ping(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -16,7 +16,7 @@ The following instructions will set up the server as well as the linters. We ass
 4. [Installation for Production (Linux)](#installation-for-production-linux)
 5. [Running the Server](#running-the-server)
 6. [Running the Server in Docker](#running-the-server-in-docker)
-
+7. [Running a Production Docker Image](#running-a-production-docker-image)
 <br />
 
 ## Installation for Development (Windows)
@@ -304,3 +304,15 @@ To manage the service:
 * If you change any of the Golang code, then you must restart the server for the changes to take effect.
 * If you change any of the TypeScript or CSS, then you will need to re-run the `build_client.sh` script in order to re-bundle it into `main.min.js` and `main.min.css`. (This step does not require a server restart, but you will need to perform a hard cache refresh in the browser.)
   * Alternatively, if you are actively changing or developing the TypeScript, leave the `webpack-dev-server.sh` script running and go to "https://localhost/dev". This way, the code will be automatically compiled whenever you change a file and the page will automatically refresh.
+
+## Running a Production Docker Image
+
+We provide a [docker-compose.yml](../docker/docker-compose.yml) file which runs mariadb, the backend and static files inside a docker container. 
+
+* [Install Docker](https://docs.docker.com/get-docker/)
+* Clone this repository into some directory. 
+* Copy `docker/.env_template` to `docker/.env` and adjust the file according to your setup. 
+* cd into the `docker` directory and run `docker-compose up --build -d` to build and then start the docker containers in the background.
+  * The database data will automatically persist inside a dedicated volume.
+  * If you restart your server, the docker containers will automatically restart. 
+  * To stop the containers, use `docker-compose down`. This will not delete the database volume. 


### PR DESCRIPTION
The existing Dockerfile is made for a development environment. In particular to run the docker-compose.yml file it is required to manually compile the frontend dependencies on the host machine. Furthermore it runs the hanabi-live daemon as root inside the docker container, which
is a security issue.

This PR adds a Dockerfile and docker-compose.yml for a production setup in the 'docker' folder. This does not have any dependencies on the host environment and can be built on a server having only a checkout of this repository and the docker-compose executable. The Dockerfile uses a common docker practice of "multi-stage builds" to achieve this. It also mitigates most security risks by running hanabi-live as a limited user within Docker.

A new section on how to start this docker image has been added to the installation documentation.

Furthermore, this PR also adds a "smoketest" for this new setup to .travis.yml. This smoketest sets up a clean environment, builds the docker image, and then starts it. Afterwards it checks if the root URL of the server returns HTTP 200.