### PR TITLE
feat: Add AllOrNothing logic to game code

### DIFF
--- a/client/src/game/ui/Deck.ts
+++ b/client/src/game/ui/Deck.ts
@@ -71,8 +71,10 @@ export default class Deck extends Konva.Group {
       h = 0.15;
     }
     this.numLeftText.y(h * this.height());
-    globals.elements.deckTurnsRemainingLabel1!.visible(count === 0);
-    globals.elements.deckTurnsRemainingLabel2!.visible(count === 0);
+    globals.elements.deckTurnsRemainingLabel1!.visible(count === 0
+      && !globals.options.allOrNothing);
+    globals.elements.deckTurnsRemainingLabel2!.visible(count === 0
+      && !globals.options.allOrNothing);
 
     // If the game ID is showing,
     // we want to center the deck count between it and the other labels

--- a/client/src/lobby/createGame.ts
+++ b/client/src/lobby/createGame.ts
@@ -183,7 +183,7 @@ const submit = () => {
       cardCycle: getCheckbox('createTableCardCycle'),
       deckPlays: getCheckbox('createTableDeckPlays'),
       emptyClues: getCheckbox('createTableEmptyClues'),
-      // allOrNothing: getCheckbox('createTableAllOrNothing'),
+      allOrNothing: getCheckbox('createTableAllOrNothing'),
       detrimentalCharacters: getCheckbox('createTableDetrimentalCharacters'),
     },
     password,

--- a/server/src/game.go
+++ b/server/src/game.go
@@ -233,6 +233,20 @@ func (g *Game) CheckEnd() bool {
 		return true
 	}
 
+	// In an AllOrNothing game, check to see if a maximum score could be reached
+	if g.Options.AllOrNothing && g.GetMaxScore() < variants[g.Options.Variant].MaxScore {
+		logger.Info(t.GetName() + "Impossible to get an AllOrNothing perfect score; ending the game.")
+		g.EndCondition = EndConditionStrikeout
+		return true
+	}
+
+	// In an AllOrNothing game, the next player must have cards or available clues
+	if g.Options.AllOrNothing && len(g.Players[g.ActivePlayer].Hand) == 0 && g.ClueTokens == 0 {
+		logger.Info(t.GetName() + "Next player ran out of moves and clues; ending the game.")
+		g.EndCondition = EndConditionStrikeout
+		return true
+	}
+
 	// Check to see if there are any cards remaining that can be played on the stacks
 	if variants[g.Options.Variant].HasReversedSuits() {
 		// Searching for the next card is much more complicated if we are playing an "Up or Down"

--- a/server/src/game_player.go
+++ b/server/src/game_player.go
@@ -477,7 +477,7 @@ func (p *GamePlayer) DrawCard() {
 	}
 
 	// Check to see if that was the last card drawn
-	if g.DeckIndex >= len(g.Deck) {
+	if g.DeckIndex >= len(g.Deck) && !g.Options.AllOrNothing {
 		// Mark the turn upon which the game will end
 		g.EndTurn = g.Turn + len(g.Players) + 1
 		characterAdjustEndTurn(g)

--- a/server/src/views/main.tmpl
+++ b/server/src/views/main.tmpl
@@ -812,7 +812,6 @@
     </div>
     <br />
 
-    <!--
     <div class="row">
       <div class="col-9 create-game-text-label">
         <div class="create-game-icon">
@@ -832,7 +831,6 @@
       </div>
     </div>
     <br />
-    -->
 
     <div class="row">
       <div class="col-9 create-game-text-label">


### PR DESCRIPTION
This patch:
* uncomments the AllOrNothing option from the UI
* adds the logic to prevent gameplay after a critical discard or when the next player has no cards and no clues
* disables setting the endTurn variable to prevent the endTurn condition firing
* prevents the "last turn" text from being applied in allornothing games, when there are no more cards in the deck