### PR TITLE
Improve replay loading (fix #1254)

### DIFF
--- a/client/src/game/ui/hypothetical.ts
+++ b/client/src/game/ui/hypothetical.ts
@@ -79,8 +79,8 @@ export const playThroughPastActions = () => {
       checkToggleRevealedButton(actionMessage);
       action(actionMessage);
     }
-    cardStatusCheck();
     globals.animateFast = false;
+    cardStatusCheck();
     globals.elements.actionLog!.refreshText();
     globals.elements.fullActionLog!.refreshText();
     globals.layers.card.batchDraw();

--- a/client/src/game/ui/replay.ts
+++ b/client/src/game/ui/replay.ts
@@ -140,8 +140,8 @@ export const goto = (target: number, fast: boolean, force?: boolean) => {
     }
   }
 
-  cardStatusCheck();
   globals.animateFast = false;
+  cardStatusCheck();
   globals.elements.actionLog!.refreshText();
   globals.elements.fullActionLog!.refreshText();
   globals.layers.card.batchDraw();

--- a/client/src/game/ui/websocket.ts
+++ b/client/src/game/ui/websocket.ts
@@ -12,7 +12,6 @@ import ReplayArrowOrder from '../types/ReplayArrowOrder';
 import State from '../types/State';
 import action from './action';
 import * as arrows from './arrows';
-import cardStatusCheck from './cardStatusCheck';
 import { checkLegal } from './clues';
 import globals from './globals';
 import * as hypothetical from './hypothetical';
@@ -487,9 +486,6 @@ commands.set('gameActionList', (data: GameActionListData) => {
     replay.goto(turnNum, true);
   }
 
-  cardStatusCheck();
-  globals.layers.card.batchDraw();
-  globals.layers.UI.batchDraw();
   globals.loading = false;
 });
 


### PR DESCRIPTION
After the last action is done when playing through past actions, we should always do a cardStatusCheck()

The deleted code in websocket.ts is redundant (and causes lag) because it already happens in the replay.goto function