### PR TITLE
Going to the lobby now resets the URL

### DIFF
--- a/client/src/game/ui/backToLobby.ts
+++ b/client/src/game/ui/backToLobby.ts
@@ -20,4 +20,7 @@ export default () => {
     tableID: globals.lobby.tableID,
   });
   globals.game!.hide();
+
+  // Reset the URL since we are now in the lobby
+  window.history.pushState('', '', '/');
 };


### PR DESCRIPTION
Usecase: I opened hanabi.live via a /replay link in discord. I press go to lobby. I don't want to view this replay anymore every time I refresh the page