### PR TITLE
Bugfix for updating card possibilities

### DIFF
--- a/client/src/game/ui/HanabiCard.ts
+++ b/client/src/game/ui/HanabiCard.ts
@@ -922,7 +922,7 @@ export default class HanabiCard extends Konva.Group implements NodeWithTooltip {
 
     // If the card was already fully-clued,
     // we already updated the possibilities for it on other cards
-    if (suit && rank && this.state.holder && !this.state.identityDetermined) {
+    if (suit && rank && !this.state.identityDetermined) {
       this.state.identityDetermined = true;
       this.updatePossibilitiesOnOtherCards(suit, rank);
     }

--- a/client/src/game/ui/action.ts
+++ b/client/src/game/ui/action.ts
@@ -237,6 +237,7 @@ actionFunctions.set('draw', (data: ActionDraw) => {
     // Since we are in a shared replay, this is a mistake, because we should have full knowledge of
     // what the card is (from the "deckOrder" message that is sent at the end of the game)
     const card = globals.deck[order];
+    card.state.holder = holder;
     card.replayRedraw();
     suit = card.state.suit;
     rank = card.state.rank;


### PR DESCRIPTION
Fix #1302 . Now, cards discarded from your own hand will properly update possibilities on other cards