### PR TITLE
Bugfix for setBareImage() optimization

### DIFF
--- a/client/src/game/ui/HanabiCard.ts
+++ b/client/src/game/ui/HanabiCard.ts
@@ -201,6 +201,7 @@ export default class HanabiCard extends Konva.Group implements NodeWithTooltip {
     if (
       this.bareName !== ''
       && globals.replay
+      && !globals.hypothetical
       && globals.turn < globals.replayTurn - 1
     ) {
       return;

--- a/client/src/game/ui/HanabiCard.ts
+++ b/client/src/game/ui/HanabiCard.ts
@@ -196,10 +196,12 @@ export default class HanabiCard extends Konva.Group implements NodeWithTooltip {
   setBareImage() {
     // Optimization: This function is expensive, so don't do it in replays
     // unless we got to the final destination
+    // However, if an action happens before the "turn" message is sent,
+    // we still need to redraw any affected cards
     if (
       this.bareName !== ''
       && globals.replay
-      && globals.replayTurn !== globals.turn
+      && globals.turn < globals.replayTurn - 1
     ) {
       return;
     }


### PR DESCRIPTION
Should fix the blank cards described in #1351 . I don't really think there's a more efficient way to do this without restructuring everything.