### PR TITLE
Fix spacing between cards on higher resolutions

### DIFF
--- a/client/src/game/ui/CardLayout.ts
+++ b/client/src/game/ui/CardLayout.ts
@@ -77,9 +77,6 @@ export default class CardLayout extends Konva.Group {
     if (n > 1) {
       dist = (lw - uw) / (n - 1);
     }
-    if (dist > 10) {
-      dist = 10;
-    }
     uw += dist * (n - 1);
 
     if (this.align === 'center' && uw < lw) {


### PR DESCRIPTION
See here https://user-images.githubusercontent.com/32303453/86517915-d7e7fc80-bdfa-11ea-9001-a5e20fae65cf.png The hands need to use proper scaling so that the cards don't bunch together like this.

btw this was original keldon code https://github.com/Zamiell/hanabi-live/blame/9b2a50c21d29131fe27a952b97e06ddba7b51388/public/js/ui.js#L782 maybe back then the cards didn't scale based on the screen resolution?