### PR TITLE
Bugfix for character metadata from db

### DIFF
--- a/server/src/character.go
+++ b/server/src/character.go
@@ -107,6 +107,11 @@ func characterGenerate(g *Game) {
 
 		for i, p := range dbPlayers {
 			g.Players[i].Character = charactersID[p.CharacterAssignment]
+			// Make sure to clear the character metadata for characters that don't depend on
+			// a random rank or color as read from the database
+			if p.CharacterAssignment > 3 {
+				p.CharacterMetadata = -1
+			}
 			g.Players[i].CharacterMetadata = p.CharacterMetadata
 		}
 		return


### PR DESCRIPTION
Characters such as Mood Swings need to start off with -1 metadata, because otherwise server thinks invalid actions occur