### PR TITLE
Fix text updates while action log is open

### DIFF
--- a/client/src/game/ui/FullActionLog.ts
+++ b/client/src/game/ui/FullActionLog.ts
@@ -96,6 +96,11 @@ export default class FullActionLog extends Konva.Group {
   addMessage(turn: number, msg: string) {
     this.buffer.push({ turnNum: turn, text: msg });
     this.needsRefresh = true;
+
+    // If the log is already open, apply the change immediately
+    if (this.isVisible()) {
+      this.refreshText();
+    }
   }
 
   // Overrides the Konva show() method to refresh the text as well


### PR DESCRIPTION
Repro: during a replay, open the full action log or a player log, press arrow left/right
Expected: text updated
Actual: text disappears