### PR TITLE
Ensure the action log is shown on first open

### DIFF
--- a/client/src/game/ui/FullActionLog.ts
+++ b/client/src/game/ui/FullActionLog.ts
@@ -113,12 +113,13 @@ export default class FullActionLog extends Konva.Group {
     if (playerIndex === -1) {
       throw new Error(`Failed to find player "${playerName}" in the player names.`);
     }
-    this.logText?.hide();
-    this.logNumbers?.hide();
 
     if (this.needsRefresh) {
       this.refreshText();
     }
+
+    this.logText!.hide();
+    this.logNumbers!.hide();
 
     if (this.playerLogs[playerIndex] === null) {
       this.playerLogEmptyMessage.show();
@@ -159,10 +160,8 @@ export default class FullActionLog extends Konva.Group {
 
   private makeLog() {
     this.logText = new MultiFitText(this.textOptions, this.maxLines);
-    this.logText.hide();
     this.add(this.logText as any);
     this.logNumbers = new MultiFitText(this.numbersOptions, this.maxLines);
-    this.logNumbers.hide();
     this.add(this.logNumbers as any);
   }
 


### PR DESCRIPTION
Repro (before this PR): open a replay, go to last turn, click action log, it's blank.