### PR TITLE
Ensure the text is hidden when clue is quack

### DIFF
--- a/client/src/game/ui/arrows.ts
+++ b/client/src/game/ui/arrows.ts
@@ -123,6 +123,7 @@ export const set = (
     ) {
       // Don't show the circle in variants where the clue types are supposed to be hidden
       arrow.circle.hide();
+      arrow.text.hide();
     } else {
       arrow.circle.show();
       if (clue.type === ClueType.Color) {


### PR DESCRIPTION
Fix quack arrow graphical glitch (reported on discord...)