### PR TITLE
discord: Reappear Discord usernames for those who don't use a nickname

### DIFF
--- a/server/src/discord.go
+++ b/server/src/discord.go
@@ -181,7 +181,11 @@ func discordGetNickname(discordID string) string {
 		logger.Info("Failed to get the Discord guild member:", err)
 		return "[error]"
 	} else {
-		return member.Nick
+		if member.Nick != "" {
+			return member.Nick
+		}
+
+		return member.User.Username
 	}
 }
 


### PR DESCRIPTION
Fixes #1659 

I tested both cases locally. With nickname and without.