### PR TITLE
Saner modal backgrounds

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -64,4 +64,7 @@
   "python.formatting.provider": "black",
   "python.linting.pylintEnabled": true,
   "python.linting.enabled": true,
+  "files.exclude": {
+    "**/misc/keldon/**": true
+  },
 }

--- a/client/src/game/ui/keyboard.ts
+++ b/client/src/game/ui/keyboard.ts
@@ -78,6 +78,11 @@ const keydown = (event: JQuery.KeyDownEvent) => {
   }
 
   if (event.key === 'Escape') {
+    // Don't do anything if there is a warning or error visible
+    if (globals.lobby.modalShowing) {
+      return;
+    }
+
     // Escape = If the chat is open, close it
     if ($('#game-chat-modal').is(':visible')) {
       globals.game!.chat.hide();

--- a/client/src/lobby/createGame.ts
+++ b/client/src/lobby/createGame.ts
@@ -1,6 +1,6 @@
 // The "Create Game" nav button
 
-import { FADE_TIME, SHUTDOWN_TIMEOUT } from '../constants';
+import { SHUTDOWN_TIMEOUT } from '../constants';
 import * as debug from '../debug';
 import { VARIANTS } from '../game/data/gameData';
 import { DEFAULT_VARIANT_NAME } from '../game/types/constants';
@@ -426,7 +426,7 @@ export const before = () => {
     return false;
   }
 
-  $('#lobby').fadeTo(FADE_TIME, 0.4);
+  modals.setShadeOpacity(0.6);
 
   return true;
 };

--- a/client/src/lobby/nav.ts
+++ b/client/src/lobby/nav.ts
@@ -1,6 +1,5 @@
 // The navigation bar at the top of the lobby
 
-import { FADE_TIME } from '../constants';
 import globals from '../globals';
 import { closeAllTooltips } from '../misc';
 import * as modals from '../modals';
@@ -114,7 +113,7 @@ const initTooltips = () => {
       'scrollableTip', // Make it scrollable
     ],
     functionBefore: () => {
-      $('#lobby').fadeTo(FADE_TIME, 0.4);
+      modals.setShadeOpacity(0.6);
     },
   };
 
@@ -132,7 +131,7 @@ const initTooltips = () => {
       }
     }
     if (tooltipsOpen <= 1) {
-      $('#lobby').fadeTo(FADE_TIME, 1);
+      modals.setShadeOpacity(0);
     }
   };
 

--- a/client/src/modals.ts
+++ b/client/src/modals.ts
@@ -1,7 +1,6 @@
 // Modals (boxes that hover on top of the UI)
 
 import { FADE_TIME } from './constants';
-import * as gameChat from './game/chat';
 import globals from './globals';
 import * as lobbyNav from './lobby/nav';
 import { closeAllTooltips, parseIntSafe } from './misc';
@@ -31,17 +30,7 @@ export const init = () => {
 
   // Warning
   $('#warning-modal-button').click(() => {
-    $('#warning-modal').fadeOut(FADE_TIME);
-    if ($('#lobby').is(':visible')) {
-      $('#lobby').fadeTo(FADE_TIME, 1, () => {
-        globals.modalShowing = false;
-      });
-    }
-    if ($('#game').is(':visible')) {
-      $('#game').fadeTo(FADE_TIME, 1, () => {
-        globals.modalShowing = false;
-      });
-    }
+    warningClose();
   });
 
   // Error
@@ -51,7 +40,7 @@ export const init = () => {
 };
 
 export const passwordShow = (tableID: number) => {
-  $('#lobby').fadeTo(FADE_TIME, 0.25);
+  setShadeOpacity(0.75);
   closeAllTooltips();
   globals.modalShowing = true;
 
@@ -62,9 +51,7 @@ export const passwordShow = (tableID: number) => {
 
 const passwordSubmit = () => {
   $('#password-modal').fadeOut(FADE_TIME);
-  $('#lobby').fadeTo(FADE_TIME, 1, () => {
-    globals.modalShowing = false;
-  });
+  setShadeOpacity(0, false);
   const tableIDString = $('#password-modal-id').val();
   if (typeof tableIDString !== 'string') {
     throw new Error('The "password-modal-id" element does not have a string value.');
@@ -87,14 +74,7 @@ const passwordSubmit = () => {
 };
 
 export const warningShow = (msg: string) => {
-  if ($('#lobby').is(':visible')) {
-    $('#lobby').fadeTo(FADE_TIME, 0.25);
-  }
-  if ($('#game').is(':visible')) {
-    $('#game').fadeTo(FADE_TIME, 0.25);
-  }
-  closeAllTooltips();
-  gameChat.hide();
+  setShadeOpacity(0.75);
   globals.modalShowing = true;
 
   $('#warning-modal-description').html(msg);
@@ -108,14 +88,7 @@ export const errorShow = (msg: string) => {
   }
   globals.errorOccurred = true;
 
-  if ($('#lobby').is(':visible')) {
-    $('#lobby').fadeTo(FADE_TIME, 0.1);
-  }
-  if ($('#game').is(':visible')) {
-    $('#game').fadeTo(FADE_TIME, 0.1);
-  }
-  closeAllTooltips();
-  gameChat.hide();
+  setShadeOpacity(0.9);
   globals.modalShowing = true;
 
   // Clear out the top navigation buttons
@@ -130,6 +103,30 @@ export const errorShow = (msg: string) => {
   }
 };
 
+// Make the page cover a certain opacity
+// If it is 0, then the page cover will be hidden
+// The second parameter is necessary to set the variable after fading finishes
+export const setShadeOpacity = (opacity: number, newModalShowing?: boolean) => {
+  const pageCover = $('#page-cover');
+  if (opacity > 0) {
+    pageCover.show();
+  }
+  // Make sure to stop any fading that was called earlier
+  pageCover.stop().fadeTo(FADE_TIME, opacity, () => {
+    if (opacity === 0) {
+      pageCover.hide();
+    }
+    if (newModalShowing !== undefined) {
+      globals.modalShowing = newModalShowing;
+    }
+  });
+};
+
+const warningClose = () => {
+  $('#warning-modal').fadeOut(FADE_TIME);
+  setShadeOpacity(0, false);
+};
+
 export const closeAll = () => {
   // Error modals cannot be closed, since we want to force the user to refresh the page
   if ($('#error-modal').is(':visible')) {
@@ -139,9 +136,6 @@ export const closeAll = () => {
   for (const modal of lobbyModals) {
     $(`#${modal}-modal`).fadeOut(FADE_TIME);
   }
-  $('#warning-modal').fadeOut(FADE_TIME);
 
-  $('#lobby').fadeTo(FADE_TIME, 1, () => {
-    globals.modalShowing = false;
-  });
+  warningClose();
 };

--- a/public/css/hanabi.css
+++ b/public/css/hanabi.css
@@ -614,12 +614,23 @@ input::-webkit-calendar-picker-indicator {
 
 .modal {
   position: absolute;
-  z-index: 1;
-  top: 5em;
+  z-index: 1000;
+  top: 15%;
   left: 5em;
   right: 5em;
   bottom: 5em;
   overflow: auto;
+}
+
+#page-cover {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-color: #001805;
+  top: 0;
+  left: 0;
+  z-index: 999;
+  opacity: 0;
 }
 
 /*

--- a/server/src/views/main.tmpl
+++ b/server/src/views/main.tmpl
@@ -1320,6 +1320,9 @@
   </section>
 </div>
 
+<!-- Page cover (which fades the background when a modal is showing) -->
+<div id="page-cover" class="hidden"></div>
+
 <!-- Used to validate that we are connecting to the correct URL -->
 <div id="domain" class="hidden">{{.Domain}}</div>
 


### PR DESCRIPTION
* Fix #1026
* Keep chat modal open (but I can't figure out a nice way to keep the password box or create game dialog open without looking like there is lag in the no-warning case. perhaps a variable that tracks lastOpenTooltip??)
* Use a solid color instead of letting the wood background bleed through (to undo this, make page-cover have the same properties as body)
* Don't allow clicking on background elements (clicking the background still closes tooltips, not sure why, but we want that)
* Yay for functionizing the code