### PR TITLE
client: Improve note parsing logic

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
   env: {
     browser: true,
     jquery: true,
+    es2020: true,
   },
 
   // We need to specify some additional settings in order to make the linter work with TypeScript:

--- a/client/src/game/data/variantsInit.ts
+++ b/client/src/game/data/variantsInit.ts
@@ -1,8 +1,10 @@
 import variantsJSON from '../../../../data/variants.json';
 import * as abbreviationsRules from '../rules/abbreviation';
+import { isNameUpOrDown } from '../rules/variant';
 import Color from '../types/Color';
 import Suit from '../types/Suit';
 import Variant from '../types/Variant';
+import { createIdentityNotePattern } from '../ui/noteIdentityPattern';
 
 // "VariantJSON" is very similar to "Variant",
 // but the latter is comprised of some more complicated objects
@@ -230,6 +232,11 @@ export default function variantsInit(
     // Prepare the abbreviations for each suit
     const abbreviations = abbreviationsRules.makeAll(name, suits);
 
+    // Create the RegEx pattern for identity notes in this variant.
+    const identityNotePattern = createIdentityNotePattern(
+      suits, ranks, abbreviations, isNameUpOrDown(name),
+    );
+
     // Add it to the map
     const variant: Variant = {
       name,
@@ -250,6 +257,7 @@ export default function variantsInit(
       maxScore,
       offsetCornerElements,
       abbreviations,
+      identityNotePattern,
     };
     VARIANTS.set(variantJSON.name, variant);
   }

--- a/client/src/game/rules/abbreviation.ts
+++ b/client/src/game/rules/abbreviation.ts
@@ -38,12 +38,10 @@ export const makeAll = (variantName: string, suits: Suit[]) => {
   return abbreviations;
 };
 
-export const get = (suitName: string, variant: Variant) => {
-  for (let i = 0; i < variant.suits.length; i++) {
-    const suit = variant.suits[i];
-    if (suit.name === suitName) {
-      return variant.abbreviations[i];
-    }
+export const get = (suitName: string, variant: Variant): string => {
+  const i = variant.suits.findIndex((suit) => suit.name === suitName);
+  if (i !== -1) {
+    return variant.abbreviations[i];
   }
 
   return '?';

--- a/client/src/game/rules/variant.ts
+++ b/client/src/game/rules/variant.ts
@@ -14,7 +14,9 @@ export const isDuck = (variant: Variant) => variant.name.startsWith('Duck');
 
 export const isThrowItInAHole = (variant: Variant) => variant.name.startsWith('Throw It in a Hole');
 
-export const isUpOrDown = (variant: Variant) => variant.name.startsWith('Up or Down');
+export const isUpOrDown = (variant: Variant) => isNameUpOrDown(variant.name);
+
+export const isNameUpOrDown = (variantName: string) => variantName.startsWith('Up or Down');
 
 export const hasReversedSuits = (variant: Variant) => {
   const suits = variant.suits;

--- a/client/src/game/types/Variant.ts
+++ b/client/src/game/types/Variant.ts
@@ -22,4 +22,6 @@ export default interface Variant {
   readonly maxScore: number;
   readonly offsetCornerElements: boolean;
   readonly abbreviations: string[];
+
+  readonly identityNotePattern: string;
 }

--- a/client/src/game/ui/HanabiCardClick.ts
+++ b/client/src/game/ui/HanabiCardClick.ts
@@ -214,7 +214,7 @@ const clickMorph = (order: number) => {
   }
 
   // We want an exact match, so fullNote is sent as an empty string
-  const cardIdentity = notes.getCardIdentityFromNote(globals.variant, cardText, '');
+  const cardIdentity = notes.getIdentityFromKeyword(globals.variant, cardText);
   if (cardIdentity.suitIndex === null || cardIdentity.rank === null) {
     modals.warningShow('You entered an invalid card.');
     return;

--- a/client/src/game/ui/noteIdentityPattern.ts
+++ b/client/src/game/ui/noteIdentityPattern.ts
@@ -1,0 +1,64 @@
+import Suit from '../types/Suit';
+
+const createSuitPattern = (suits: Suit[], abbreviations: string[]): string => {
+  let alternation = '';
+  suits.forEach((suit, i) => {
+    if (i !== 0) {
+      alternation += '|';
+    }
+
+    alternation += abbreviations[i].toLowerCase();
+    alternation += '|';
+    alternation += suit.displayName.toLowerCase();
+  });
+
+  return `(${alternation})`;
+};
+
+const createRankPattern = (ranks: number[], isUpOrDown: boolean): string => {
+  let rankStrings = ranks.map((r) => r.toString());
+  if (isUpOrDown) {
+    rankStrings = rankStrings.concat('0', 's', 'start');
+  }
+
+  return `(${rankStrings.join('|')})`;
+};
+
+export const createIdentityNotePattern = (
+  suits: Suit[],
+  ranks: number[],
+  abbreviations: string[],
+  isUpOrDown: boolean,
+): string => {
+  const suitPattern = createSuitPattern(suits, abbreviations);
+  const rankPattern = createRankPattern(ranks, isUpOrDown);
+  return `^(?:${suitPattern} ?${rankPattern}|${rankPattern} ?${suitPattern}|${suitPattern}|${rankPattern})$`;
+};
+
+export const extractSuitText = (match: RegExpMatchArray): string | null => {
+  if (match[1] !== undefined) {
+    return match[1];
+  }
+  if (match[4] !== undefined) {
+    return match[4];
+  }
+  if (match[5] !== undefined) {
+    return match[5];
+  }
+
+  return null;
+};
+
+export const extractRankText = (match: RegExpMatchArray): string | null => {
+  if (match[2] !== undefined) {
+    return match[2];
+  }
+  if (match[3] !== undefined) {
+    return match[3];
+  }
+  if (match[6] !== undefined) {
+    return match[6];
+  }
+
+  return null;
+};

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -5,17 +5,20 @@
     // By default, it will put the compiled ".js" and ".js.map" next to the respective ".ts"
     // file, which will clutter the "src" directory
     "outDir": "./dist",
-
     // "target" specifies the ECMAScript target version
     // By default, it is "ES3"
     // This is too conservative; the project targets browsers within a 2 year time-frame
     "target": "ES2018",
-
+    // "lib" specifies the JavaScript features used.
+    "lib": [
+      "DOM",
+      // We use "ES2020.String" for RegEx matchAll()
+      "ES2020.String"
+    ],
     // "newLine" specifies the end of line sequence
     // By default, it is "crlf" on Windows; we want to always use "lf" in order to match the
     // code base and reduce the file size of the output
     "newLine": "lf",
-
     // "moduleResolution" specifies how modules (imports) get resolved
     // By default, it is "Classic", but this is a legacy option,
     // and Node will be the default in the future
@@ -23,30 +26,25 @@
     // Specifying "Node" here is also necessary in order for JSON files to be imported without
     // erroring
     "moduleResolution": "Node",
-
     // "resolveJsonModule" includes modules imported with ".json" extensions
     // By default, it is false
     // We import JSON files in the code base, so this is needed
     "resolveJsonModule": true,
-
     // "esModuleInterop" emits "__importStar" and "__importDefault" helpers for ecosystem
     // compatibility and enables the "--allowSyntheticDefaultImports" flag for typesystem
     // compatibility
     // By default, it is false
     // Specifying this is needed for various JavaScript libraries to work with TypeScript
     "esModuleInterop": true,
-
     // TypeScript will not remove comments by default;
     // we want to remove them to make the source file smaller
     "removeComments": true,
-
     // We want the compiler to be as strict as possible to catch all the things
     // By default, these flags are false
     "strict": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-
     // By default, TypeScript will remove all blank lines
     // This will cause the source maps to report the wrong line numbers
     // We must specify both of these options in order to fix the problem
@@ -54,10 +52,8 @@
     "sourceMap": true,
     "inlineSources": true,
   },
-
   "include": [
     "./src/**/*.ts",
-
     // These files are not intended to be compiled, but we include them to suppress ESLint warnings
     "./Gruntfile.js",
     "./webpack.config.js",


### PR DESCRIPTION
This makes the note parsing logic do far less work. This changes behavior in two ways:

- Partial identity notes can now combine, for example `[r] [1]` now produces a morphed red 1
- Abbreviation identity notes can now have a space in the middle, for example `r 1` now produces a morphed red 1

I have tested this locally extensively