### PR TITLE
Respect Empathy when drawing new cards

### DIFF
--- a/client/src/game/ui/CardLayout.ts
+++ b/client/src/game/ui/CardLayout.ts
@@ -53,6 +53,9 @@ export default class CardLayout extends Konva.Group {
     const pos = child.getAbsolutePosition();
     this.add(child as any);
     child.setAbsolutePosition(pos);
+    if (this.empathy) {
+      child.card.setEmpathy(true);
+    }
     this.doLayout();
   }
 


### PR DESCRIPTION
If user is working hard to hold down space bar or left mouse in a replay while also navigating left/right arrow then they may not want to see the new cards either. This would be a useful change in behavior for me if I want to follow through a replay for practice pretending to be Alice (so I can hold down left mouse button without seeing new cards).

For the record, this is (i) my first pull request, (ii) I wrote it on 0 hours of sleep (insomnia), so if this is a bad idea no need to be polite about it.