### PR TITLE
Close dialogs under warnings and errors

### DIFF
--- a/client/src/modals.ts
+++ b/client/src/modals.ts
@@ -74,6 +74,7 @@ const passwordSubmit = () => {
 };
 
 export const warningShow = (msg: string) => {
+  closeAllTooltips();
   setShadeOpacity(0.75);
   globals.modalShowing = true;
 
@@ -88,6 +89,7 @@ export const errorShow = (msg: string) => {
   }
   globals.errorOccurred = true;
 
+  closeAllTooltips();
   setShadeOpacity(0.9);
   globals.modalShowing = true;
 


### PR DESCRIPTION
otherwise it's buggy; for one dialogs and errors use the same shade which results in behavior like the Create Game dialog over the error message over the page cover

(this is also how it was before my PR)