### PR TITLE
Identity list note

### DIFF
--- a/client/src/game/types/CardNote.ts
+++ b/client/src/game/types/CardNote.ts
@@ -1,5 +1,5 @@
 export default interface CardNote {
-  // The possible card identities included in the note. Empty if none.
+  // The possible card identities included in the note (empty if none)
   possibilities: Array<[number, number]>;
   readonly knownTrash: boolean;
   readonly needsFix: boolean;

--- a/client/src/game/types/CardNote.ts
+++ b/client/src/game/types/CardNote.ts
@@ -1,8 +1,6 @@
 export default interface CardNote {
-  // The suit corresponding to the note written on the card, if any
-  suitIndex: number | null;
-  // The rank corresponding to the note written on the card, if any
-  rank: number | null;
+  // The possible card identities included in the note. Empty if none.
+  possibilities: Array<[number, number]>;
   readonly knownTrash: boolean;
   readonly needsFix: boolean;
   readonly chopMoved: boolean;

--- a/client/src/game/ui/HanabiCard.ts
+++ b/client/src/game/ui/HanabiCard.ts
@@ -579,8 +579,18 @@ export default class HanabiCard extends Konva.Group implements NodeWithTooltip {
     for (const rank of this.variant.ranks)
       rankPipStates[rank] = PipState.Hidden;
 
+    const possibleCards = this.empathy
+      ? this.state.possibleCardsFromClues
+      : this.note.possibilities.filter(
+          ([suitIndexA, rankA]) =>
+            this.state.possibleCardsFromClues.findIndex(
+              ([suitIndexB, rankB]) =>
+                suitIndexA === suitIndexB && rankA === rankB,
+            ) !== -1,
+        );
+
     // We look through each card that should have a visible pip (eliminated or not)
-    for (const [suitIndex, rank] of this.state.possibleCardsFromClues) {
+    for (const [suitIndex, rank] of possibleCards) {
       // If the card is impossible, eliminate it
       const pipState =
         this.state.possibleCardsFromObservation[suitIndex][rank] > 0

--- a/client/src/game/ui/HanabiCard.ts
+++ b/client/src/game/ui/HanabiCard.ts
@@ -402,7 +402,9 @@ export default class HanabiCard extends Konva.Group implements NodeWithTooltip {
           ) !== -1,
       );
       const candidateRank = possibleCardsFromNoteAndClues[0][1];
-      if (possibleCardsFromNoteAndClues.every((card) => rank === card[1])) {
+      if (
+        possibleCardsFromNoteAndClues.every((card) => card[1] === candidateRank)
+      ) {
         noteRank = candidateRank;
       }
     }

--- a/client/src/game/ui/HanabiCard.ts
+++ b/client/src/game/ui/HanabiCard.ts
@@ -401,12 +401,8 @@ export default class HanabiCard extends Konva.Group implements NodeWithTooltip {
               suitIndexA === suitIndexB && rankA === rankB,
           ) !== -1,
       );
-      const [, candidateRank] = possibleCardsFromNoteAndClues[0];
-      if (
-        possibleCardsFromNoteAndClues.every(
-          ([, rank]) => rank === candidateRank,
-        )
-      ) {
+      const candidateRank = possibleCardsFromNoteAndClues[0][1];
+      if (possibleCardsFromNoteAndClues.every((card) => rank === card[1])) {
         noteRank = candidateRank;
       }
     }

--- a/client/src/game/ui/HanabiCard.ts
+++ b/client/src/game/ui/HanabiCard.ts
@@ -359,9 +359,16 @@ export default class HanabiCard extends Konva.Group implements NodeWithTooltip {
     // If we have a note on the card and it only provides possibilities of the same suit,
     // show that suit
     if (this.note.possibilities.length !== 0) {
-      const [candidateSuitIndex] = this.note.possibilities[0];
+      const possibleCardsFromNoteAndClues = this.note.possibilities.filter(
+        ([suitIndexA, rankA]) =>
+          this.state.possibleCardsFromClues.findIndex(
+            ([suitIndexB, rankB]) =>
+              suitIndexA === suitIndexB && rankA === rankB,
+          ) !== -1,
+      );
+      const [candidateSuitIndex] = possibleCardsFromNoteAndClues[0];
       if (
-        this.note.possibilities.every(
+        possibleCardsFromNoteAndClues.every(
           ([suitIndex]) => suitIndex === candidateSuitIndex,
         )
       ) {
@@ -387,8 +394,19 @@ export default class HanabiCard extends Konva.Group implements NodeWithTooltip {
 
     let noteRank = null;
     if (this.note.possibilities.length !== 0) {
-      const [, candidateRank] = this.note.possibilities[0];
-      if (this.note.possibilities.every(([, rank]) => rank === candidateRank)) {
+      const possibleCardsFromNoteAndClues = this.note.possibilities.filter(
+        ([suitIndexA, rankA]) =>
+          this.state.possibleCardsFromClues.findIndex(
+            ([suitIndexB, rankB]) =>
+              suitIndexA === suitIndexB && rankA === rankB,
+          ) !== -1,
+      );
+      const [, candidateRank] = possibleCardsFromNoteAndClues[0];
+      if (
+        possibleCardsFromNoteAndClues.every(
+          ([, rank]) => rank === candidateRank,
+        )
+      ) {
         noteRank = candidateRank;
       }
     }

--- a/client/src/game/ui/HanabiCard.ts
+++ b/client/src/game/ui/HanabiCard.ts
@@ -381,8 +381,8 @@ export default class HanabiCard extends Konva.Group implements NodeWithTooltip {
       return UNKNOWN_CARD_RANK;
     }
 
-    // If we have a note on the card, and it only provides possibilities of the same rank,
-    // show that rank. (specifically for stack bases in ongoing games; we want notes to have
+    // If we have a note on the card and it only provides possibilities of the same rank,
+    // show that rank (specifically for stack bases in ongoing games; we want notes to have
     // precedence in this case so that players can make notes in "Throw It in a Hole" variants)
 
     let noteRank = null;

--- a/client/src/game/ui/HanabiCard.ts
+++ b/client/src/game/ui/HanabiCard.ts
@@ -1126,6 +1126,9 @@ export default class HanabiCard extends Konva.Group implements NodeWithTooltip {
     // (or clear the bare image if the note was deleted/changed)
     this.setBareImage();
 
+    // Update the pips if the note changed them.
+    this.updatePips();
+
     // Since we updated the note, we might need to redraw a special border around the card
     this.setBorder();
 
@@ -1156,5 +1159,6 @@ export default class HanabiCard extends Konva.Group implements NodeWithTooltip {
 
     this.empathy = enabled;
     this.setBareImage();
+    this.updatePips();
   }
 }

--- a/client/src/game/ui/HanabiCard.ts
+++ b/client/src/game/ui/HanabiCard.ts
@@ -579,7 +579,8 @@ export default class HanabiCard extends Konva.Group implements NodeWithTooltip {
     for (const rank of this.variant.ranks)
       rankPipStates[rank] = PipState.Hidden;
 
-    const possibleCards = this.empathy
+    const ignoreNote = this.empathy || this.note.possibilities.length === 0;
+    const possibleCards = ignoreNote
       ? this.state.possibleCardsFromClues
       : this.note.possibilities.filter(
           ([suitIndexA, rankA]) =>

--- a/client/src/game/ui/HanabiCardClick.ts
+++ b/client/src/game/ui/HanabiCardClick.ts
@@ -234,7 +234,7 @@ function clickMorph(order: number) {
   }
 
   // We want an exact match, so fullNote is sent as an empty string
-  const cardIdentity = notes.getIdentityFromKeyword(globals.variant, cardText);
+  const cardIdentity = notes.parseIdentity(globals.variant, cardText);
   if (cardIdentity.suitIndex === null || cardIdentity.rank === null) {
     modals.warningShow("You entered an invalid card.");
     return;

--- a/client/src/game/ui/HanabiCardMouse.ts
+++ b/client/src/game/ui/HanabiCardMouse.ts
@@ -196,7 +196,7 @@ function shouldShowLookCursor(card: HanabiCard) {
 
   // For ongoing games, only show the cursor for our hand if it has a custom card identity
 
-  // Check if there exists a possibility from clues that the note declares impossible.
+  // Check if there exists a possibility from clues that the note declares impossible
   const noteNarrowsPossibilities =
     card.note.possibilities.length !== 0 &&
     card.state.possibleCardsFromClues.some(

--- a/client/src/game/ui/HanabiCardMouse.ts
+++ b/client/src/game/ui/HanabiCardMouse.ts
@@ -195,13 +195,17 @@ function shouldShowLookCursor(card: HanabiCard) {
   }
 
   // For ongoing games, only show the cursor for our hand if it has a custom card identity
-  if (
-    (card.note.suitIndex !== null &&
-      card.note.suitIndex !== card.state.suitIndex) ||
-    (card.note.rank !== null && card.note.rank !== card.state.rank) ||
-    card.note.blank ||
-    card.note.unclued
-  ) {
+
+  // Check if there exists a possibility from clues that the note declares impossible.
+  const noteNarrowsPossibilities =
+    card.note.possibilities.length !== 0 &&
+    card.state.possibleCardsFromClues.some(
+      ([suitIndexA, rankA]) =>
+        card.note.possibilities.findIndex(
+          ([suitIndexB, rankB]) => suitIndexA === suitIndexB && rankA === rankB,
+        ) === -1,
+    );
+  if (noteNarrowsPossibilities || card.note.blank || card.note.unclued) {
     return true;
   }
 

--- a/client/src/game/ui/notes.ts
+++ b/client/src/game/ui/notes.ts
@@ -282,6 +282,9 @@ export function checkNoteImpossibility(
   note: CardNote,
 ): void {
   const { possibilities } = note;
+  if (possibilities.length === 0) {
+    return;
+  }
   // Prevent players from accidentally mixing up which stack base is which
   if (
     cardState.rank === STACK_BASE_RANK &&

--- a/client/src/game/ui/notes.ts
+++ b/client/src/game/ui/notes.ts
@@ -258,17 +258,15 @@ export function getPossibilitiesFromKeywords(
     if (newPossibilities === null) {
       continue;
     }
-    const intersection = [];
-    for (const possibility of newPossibilities) {
-      if (
-        possibilities.findIndex(
-          (elem) => elem[0] === possibility[0] && elem[1] === possibility[1],
-        ) !== -1
-      ) {
-        intersection.push(possibility);
-      }
-    }
-    // if this new term completely conflicts with the previous terms, then reset our state to
+    const oldPossibilities = possibilities;
+    const intersection = newPossibilities.filter(
+      ([newSuitIndex, newRank]) =>
+        oldPossibilities.findIndex(
+          ([oldSuitIndex, oldRank]) =>
+            newSuitIndex === oldSuitIndex && newRank === oldRank,
+        ) !== -1,
+    );
+    // If this new term completely conflicts with the previous terms, then reset our state to
     // just the new term
     possibilities = intersection.length === 0 ? newPossibilities : intersection;
   }

--- a/client/src/game/ui/notes.ts
+++ b/client/src/game/ui/notes.ts
@@ -221,7 +221,7 @@ function getPossibilitiesFromKeyword(
         }
       }
     } else {
-      // Encountered invalid identity. do not parse keyword as an identity list
+      // Encountered invalid identity; do not parse keyword as an identity list
       return null;
     }
   }
@@ -305,7 +305,7 @@ export function checkNoteImpossibility(
     return;
   }
 
-  // We have specified a list of identities where none are possible.
+  // We have specified a list of identities where none are possible
   const impossibilities = Array.from(possibilities, ([suitIndex, rank]) => {
     const suitName = variant.suits[suitIndex].displayName;
     const impossibleSuit = suitName.toLowerCase();

--- a/client/src/game/ui/notes.ts
+++ b/client/src/game/ui/notes.ts
@@ -182,9 +182,9 @@ function getPossibilitiesFromKeyword(
   for (const substring of keyword.split(",")) {
     const identity = parseIdentity(variant, substring);
     if (identity.suitIndex !== null && identity.rank !== null) {
-      // encountered an identity item, add it
+      // Encountered an identity item, add it
 
-      // check that this identity is not already present in the list
+      // Check that this identity is not already present in the list
       if (
         possibilities.findIndex(
           (possibility) =>
@@ -195,9 +195,9 @@ function getPossibilitiesFromKeyword(
         possibilities.push([identity.suitIndex, identity.rank]);
       }
     } else if (identity.suitIndex !== null && identity.rank === null) {
-      // encountered a suit item, expand to all cards of that suit.
+      // Encountered a suit item, expand to all cards of that suit
       for (const rank of variant.ranks) {
-        // check that this identity is not already present in the list
+        // Check that this identity is not already present in the list
         if (
           possibilities.findIndex(
             (possibility) =>
@@ -208,9 +208,9 @@ function getPossibilitiesFromKeyword(
         }
       }
     } else if (identity.suitIndex === null && identity.rank !== null) {
-      // encountered a rank item, expand to all cards of that rank.
+      // Encountered a rank item, expand to all cards of that rank
       for (let suitIndex = 0; suitIndex < variant.suits.length; suitIndex++) {
-        // check that this identity is not already present in the list
+        // Check that this identity is not already present in the list
         if (
           possibilities.findIndex(
             (possibility) =>
@@ -221,7 +221,7 @@ function getPossibilitiesFromKeyword(
         }
       }
     } else {
-      // encountered invalid identity. do not parse keyword as identity list.
+      // Encountered invalid identity. do not parse keyword as an identity list
       return null;
     }
   }

--- a/client/src/game/ui/notes.ts
+++ b/client/src/game/ui/notes.ts
@@ -106,7 +106,7 @@ export function checkNoteIdentity(variant: Variant, note: string): CardNote {
   // and remove all leading and trailing whitespace
   const fullNote = note.toLowerCase().trim();
   const keywords = getNoteKeywords(fullNote);
-  const cardIdentity = getIdentityFromKeywords(variant, keywords);
+  const possibilities = getPossibilitiesFromKeywords(variant, keywords);
 
   const chopMoved = checkNoteKeywordsForMatch(
     [
@@ -139,8 +139,7 @@ export function checkNoteIdentity(variant: Variant, note: string): CardNote {
   const unclued = checkNoteKeywordsForMatch(["unclued"], keywords);
 
   return {
-    suitIndex: cardIdentity.suitIndex,
-    rank: cardIdentity.rank,
+    possibilities,
     chopMoved,
     finessed,
     knownTrash,
@@ -175,10 +174,62 @@ function parseRank(rankText: string): number {
   return rank;
 }
 
-export function getIdentityFromKeyword(
+function getPossibilitiesFromKeyword(
   variant: Variant,
   keyword: string,
-): CardIdentity {
+): Array<[number, number]> | null {
+  const possibilities: Array<[number, number]> = [];
+  for (const substring of keyword.split(",")) {
+    const identity = parseIdentity(variant, substring);
+    if (identity.suitIndex !== null && identity.rank !== null) {
+      // encountered an identity item, add it
+
+      // check that this identity is not already present in the list
+      if (
+        possibilities.findIndex(
+          (possibility) =>
+            possibility[0] === identity.suitIndex &&
+            possibility[1] === identity.rank,
+        ) === -1
+      ) {
+        possibilities.push([identity.suitIndex, identity.rank]);
+      }
+    } else if (identity.suitIndex !== null && identity.rank === null) {
+      // encountered a suit item, expand to all cards of that suit.
+      for (const rank of variant.ranks) {
+        // check that this identity is not already present in the list
+        if (
+          possibilities.findIndex(
+            (possibility) =>
+              possibility[0] === identity.suitIndex && possibility[1] === rank,
+          ) === -1
+        ) {
+          possibilities.push([identity.suitIndex, rank]);
+        }
+      }
+    } else if (identity.suitIndex === null && identity.rank !== null) {
+      // encountered a rank item, expand to all cards of that rank.
+      for (let suitIndex = 0; suitIndex < variant.suits.length; suitIndex++) {
+        // check that this identity is not already present in the list
+        if (
+          possibilities.findIndex(
+            (possibility) =>
+              possibility[0] === suitIndex && possibility[1] === identity.rank,
+          ) === -1
+        ) {
+          possibilities.push([suitIndex, identity.rank]);
+        }
+      }
+    } else {
+      // encountered invalid identity. do not parse keyword as identity list.
+      return null;
+    }
+  }
+
+  return possibilities;
+}
+
+export function parseIdentity(variant: Variant, keyword: string): CardIdentity {
   const identityMatch = new RegExp(variant.identityNotePattern).exec(keyword);
   let suitIndex = null;
   let rank = null;
@@ -196,44 +247,33 @@ export function getIdentityFromKeyword(
   return { suitIndex, rank };
 }
 
-export function getIdentityFromKeywords(
+export function getPossibilitiesFromKeywords(
   variant: Variant,
   keywords: string[],
-): CardIdentity {
-  let suitIndex = null;
-  let rank = null;
+): Array<[number, number]> {
+  let possibilities: Array<[number, number]> = [];
 
-  for (let i = keywords.length - 1; i >= 0; i--) {
-    const keyword = keywords[i];
-
-    const { suitIndex: newSuitIndex, rank: newRank } = getIdentityFromKeyword(
-      variant,
-      keyword,
-    );
-    if (
-      suitIndex !== null &&
-      newSuitIndex !== null &&
-      newSuitIndex !== suitIndex
-    ) {
-      break;
+  for (const keyword of keywords) {
+    const newPossibilities = getPossibilitiesFromKeyword(variant, keyword);
+    if (newPossibilities === null) {
+      continue;
     }
-    if (rank !== null && newRank !== null && newRank !== rank) {
-      break;
+    const intersection = [];
+    for (const possibility of newPossibilities) {
+      if (
+        possibilities.findIndex(
+          (elem) => elem[0] === possibility[0] && elem[1] === possibility[1],
+        ) !== -1
+      ) {
+        intersection.push(possibility);
+      }
     }
-
-    if (newSuitIndex !== null) {
-      suitIndex = newSuitIndex;
-    }
-    if (newRank !== null) {
-      rank = newRank;
-    }
-
-    if (suitIndex !== null && rank !== null) {
-      break;
-    }
+    // if this new term completely conflicts with the previous terms, then reset our state to
+    // just the new term
+    possibilities = intersection.length === 0 ? newPossibilities : intersection;
   }
 
-  return { suitIndex, rank };
+  return possibilities;
 }
 
 export function checkNoteImpossibility(
@@ -241,65 +281,44 @@ export function checkNoteImpossibility(
   cardState: CardState,
   note: CardNote,
 ): void {
+  const { possibilities } = note;
   // Prevent players from accidentally mixing up which stack base is which
   if (
     cardState.rank === STACK_BASE_RANK &&
-    note.suitIndex !== null &&
-    note.suitIndex !== cardState.suitIndex
+    possibilities.every((possibility) => possibility[0] !== cardState.suitIndex)
   ) {
     modals.warningShow(
       "You cannot morph a stack base to have a different suit.",
     );
-    note.suitIndex = null;
-    note.rank = null;
+    note.possibilities = [];
     return;
   }
 
   // Only validate cards in our own hand
   if (
     !(cardState.location === globals.metadata.ourPlayerIndex) ||
-    canPossiblyBe(cardState, note.suitIndex, note.rank)
+    possibilities.some((possibility) =>
+      canPossiblyBe(cardState, possibility[0], possibility[1]),
+    )
   ) {
     return;
   }
 
-  // We have specified a note identity that is impossible
-  let impossibleSuit = "unknown";
-  if (note.suitIndex !== null) {
-    const suitName = variant.suits[note.suitIndex].displayName;
-    impossibleSuit = suitName.toLowerCase();
-  }
-  let impossibleRank = "unknown";
-  if (note.rank !== null) {
-    if (note.rank === START_CARD_RANK) {
-      impossibleRank = "START";
-    } else {
-      impossibleRank = note.rank.toString();
-    }
-  }
-
-  if (note.suitIndex !== null && note.rank === null) {
-    // Only the suit was specified
-    modals.warningShow(`That card cannot possibly be ${impossibleSuit}.`);
-    note.suitIndex = null;
-    return;
-  }
-
-  if (note.suitIndex === null && note.rank !== null) {
-    // Only the rank was specified
-    modals.warningShow(`That card cannot possibly be a ${impossibleRank}.`);
-    note.rank = null;
-    return;
-  }
-
-  if (note.suitIndex !== null && note.rank !== null) {
-    // Both the suit and the rank were specified
+  // We have specified a list of identities where none are possible.
+  const impossibilities = Array.from(possibilities, ([suitIndex, rank]) => {
+    const suitName = variant.suits[suitIndex].displayName;
+    const impossibleSuit = suitName.toLowerCase();
+    const impossibleRank = rank === START_CARD_RANK ? "START" : rank.toString();
+    return `${impossibleSuit} ${impossibleRank}`;
+  });
+  if (impossibilities.length === 1) {
+    modals.warningShow(`That card cannot possibly be ${impossibilities[0]}`);
+  } else {
     modals.warningShow(
-      `That card cannot possibly be a ${impossibleSuit} ${impossibleRank}.`,
+      `That card cannot possibly be any of ${impossibilities.join(", ")}`,
     );
-    note.suitIndex = null;
-    note.rank = null;
   }
+  note.possibilities = [];
 }
 
 export function update(card: HanabiCard): void {

--- a/client/src/game/ui/reactive/view/cardsView.ts
+++ b/client/src/game/ui/reactive/view/cardsView.ts
@@ -143,6 +143,15 @@ function subscribeToCardChanges(order: number) {
     () => updateCardStatus(order),
   );
 
+  // Notes
+  sub(
+    (c) => ({
+      possibleCardsFromClues: c.possibleCardsFromClues,
+      possibleCardsFromObservation: c.possibleCardsFromObservation,
+    }),
+    () => checkNoteDisproved(order),
+  );
+
   // Pips
   sub(
     (c) => ({
@@ -151,15 +160,6 @@ function subscribeToCardChanges(order: number) {
       numPositiveRankClues: c.positiveRankClues.length,
     }),
     () => updatePips(order),
-  );
-
-  // Notes
-  sub(
-    (c) => ({
-      possibleCardsFromClues: c.possibleCardsFromClues,
-      possibleCardsFromObservation: c.possibleCardsFromObservation,
-    }),
-    () => checkNoteDisproved(order),
   );
 
   // Card visuals
@@ -172,6 +172,7 @@ function subscribeToCardChanges(order: number) {
         location: card.location,
         suitDetermined: card.suitDetermined,
         rankDetermined: card.rankDetermined,
+        numPossibleCardsFromClues: card.possibleCardsFromClues.length,
         identity: s.cardIdentities[order],
       };
     },


### PR DESCRIPTION
This sets up parsing for identity list notes and causes a note like `g2, r2` to morph the card into a 2.

Resolves #1739 

TODO:
- [x] Parse shorthand. (e.g `gr2`) EDIT: let's leave this for another PR
- [x] Change pips corresponding to such a note in addition to the aforementioned morphing. (e.g. `g2,r2` produces a morphed 2 with a green pip and a red pip.)