### PR TITLE
Fix whitespace after comma in identity list notes

### DIFF
--- a/client/src/game/ui/notes.ts
+++ b/client/src/game/ui/notes.ts
@@ -180,7 +180,7 @@ function getPossibilitiesFromKeyword(
 ): Array<[number, number]> | null {
   const possibilities: Array<[number, number]> = [];
   for (const substring of keyword.split(",")) {
-    const identity = parseIdentity(variant, substring);
+    const identity = parseIdentity(variant, substring.trim());
     if (identity.suitIndex !== null && identity.rank !== null) {
       // Encountered an identity item, add it
 


### PR DESCRIPTION
Fix #1836 