### PR TITLE
CSS versioning for cache busting after restart

### DIFF
--- a/server/src/http.go
+++ b/server/src/http.go
@@ -26,6 +26,8 @@ type TemplateData struct {
 	Compiling   bool // True if we are currently recompiling the TypeScript client
 	WebpackPort int
 
+	CSSVersion int64 // for CSS Cache busting after server restart
+
 	// Profile
 	Name       string
 	NamesTitle string
@@ -402,6 +404,9 @@ func httpServeTemplate(w http.ResponseWriter, data TemplateData, templateName ..
 
 	// Add extra data that should be the same for every page request
 	data.WebsiteName = WebsiteName
+
+	// Add datetimeStarted in seconds from Unix epoch for css cache busting
+	data.CSSVersion = datetimeStarted.Unix()
 
 	// Execute the template and send it to the user
 	if err := tmpl.ExecuteTemplate(w, "layout", data); err != nil {

--- a/server/src/views/layout.tmpl
+++ b/server/src/views/layout.tmpl
@@ -48,8 +48,8 @@
     <link rel="stylesheet" type="text/css" href="/public/css/hanabi.css" />
   {{else}}
     <!-- Delay loading non-critical CSS -->
-    <link rel="preload" type="text/css" href="/public/css/main.min.css" as="style">
-    <link rel="stylesheet" type="text/css" href="/public/css/main.min.css">
+    <link rel="preload" type="text/css" href="/public/css/main.min.css?v={{.CSSVersion}}" as="style">
+    <link rel="stylesheet" type="text/css" href="/public/css/main.min.css?v={{.CSSVersion}}">
   {{end}}
   <link rel="icon" type="image/png" sizes="32x32" href="/public/img/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/public/img/favicon-16x16.png">


### PR DESCRIPTION
Puts a query string after main.min.css based on server start time. Used by browsers for CSS cache busting, so no need for hard reloads.