### PR TITLE
Impostor

### DIFF
--- a/client/src/chat.ts
+++ b/client/src/chat.ts
@@ -41,6 +41,7 @@ const serverSideOnlyCommands = [
   "s6",
   "startin",
   "kick",
+  "impostor",
 
   // Pre-game or game commands
   "missing",

--- a/docs/CHAT_COMMANDS.md
+++ b/docs/CHAT_COMMANDS.md
@@ -50,6 +50,7 @@ If you need general help with the website, then read the [features page](FEATURE
 | `/s6`                   | Automatically start the game when it has 6 players
 | `/startin [minutes]`    | Automatically start the game in the provided amount of minutes
 | `/kick [username]`      | Remove a player from the table
+| `/impostor`             | Randomly tells one of the players they are an impostor and the others they are crewmates.
 
 <br />
 

--- a/docs/CHAT_COMMANDS.md
+++ b/docs/CHAT_COMMANDS.md
@@ -50,7 +50,7 @@ If you need general help with the website, then read the [features page](FEATURE
 | `/s6`                   | Automatically start the game when it has 6 players
 | `/startin [minutes]`    | Automatically start the game in the provided amount of minutes
 | `/kick [username]`      | Remove a player from the table
-| `/impostor`             | Randomly tells one of the players they are an impostor and the others they are crewmates.
+| `/impostor`             | Randomly tells one of the players they are an impostor and the others they are crew-mates.
 
 <br />
 

--- a/server/src/chat_command.go
+++ b/server/src/chat_command.go
@@ -38,6 +38,7 @@ func chatCommandInit() {
 	chatCommandMap["s6"] = chatS6
 	chatCommandMap["startin"] = chatStartIn
 	chatCommandMap["kick"] = chatKick
+	chatCommandMap["impostor"] = chatImpostor
 
 	// Table-only commands (pregame or game)
 	chatCommandMap["missing"] = chatMissingScores


### PR DESCRIPTION
When the table leader issues `/impostor` the website will randomly tell one of the players they are an IMPOSTOR and the other players that they are a CREWMATE.

(Intended use case: players agree on a threshold N where the crewmates win if they either score at least N, or they successfully guess who the impostor is during review.)