### PR TITLE
only increment discarded cards if not a strike

### DIFF
--- a/client/src/game/reducers/turnReducer.ts
+++ b/client/src/game/reducers/turnReducer.ts
@@ -43,7 +43,9 @@ function turnReducerFunction(
 
     case "discard": {
       turn.cardsPlayedOrDiscardedThisTurn += 1;
-      turn.cardsDiscardedThisTurn += 1;
+      if (!action.failed) {
+        turn.cardsDiscardedThisTurn += 1;
+      }
 
       if (currentState.cardsRemainingInTheDeck === 0) {
         turn.segment! += 1;


### PR DESCRIPTION
Fixes https://github.com/Zamiell/hanabi-live/issues/1735

`cardsDiscardedThisTurn` is only used in [shouldEndTurnAfterDraw](https://github.com/Zamiell/hanabi-live/blob/master/client/src/game/rules/turn.ts#L7) when deciding if the panicky player's turn should continue. This change makes sure that this variable is not incremented after a misplay. 

**QA**
- tested that misplaying as panicky with < 5 clues advances turn
- tested that discarding, playing, cluing, and striking advance turn in normal cases