### PR TITLE
Stats minor fix

### DIFF
--- a/client/src/game/rules/card.ts
+++ b/client/src/game/rules/card.ts
@@ -181,6 +181,19 @@ export function allPossibilitiesTrash(
   playStackDirections: readonly StackDirection[],
   variant: Variant,
 ): boolean {
+  // If we fully know the card already, just check if it's playable
+  if (card.rank != null && card.suitIndex != null) {
+    return !needsToBePlayed(
+      card.suitIndex,
+      card.rank,
+      deck,
+      playStacks,
+      playStackDirections,
+      variant,
+    );
+  }
+
+  // Otherwise, check based on possibilities from clues
   for (const [suitIndex, rank] of card.possibleCardsFromClues) {
     if (card.possibleCardsFromObservation[suitIndex][rank] === 0) continue;
     if (

--- a/client/src/game/ui/reactive/view/statsView.ts
+++ b/client/src/game/ui/reactive/view/statsView.ts
@@ -63,7 +63,7 @@ export function onEfficiencyChanged(data: {
     cardsGottenByNotes = null;
   }
 
-  const cardsNotGotten = data.maxScore - cardsGotten;
+  const cardsNotGotten = Math.max(data.maxScore - cardsGotten, 0);
 
   const efficiency = statsRules.efficiency(
     cardsGotten,


### PR DESCRIPTION
Two changes:

* If a card is known (e.g. we are Alice and see it in Bob's hand), then `allPossibilitiesTrash` will just use the known identity instead rather than the clued information. (Thus, trash cards essentially do not need `kt` notes anymore to get the efficiency correct.)

* Don't allow negative future efficiencies.

If a card is duplicated it will still count doubled until one of them plays, alas.