### PR TITLE
Update ref to conventions in bot commands

### DIFF
--- a/server/src/chat_general.go
+++ b/server/src/chat_general.go
@@ -29,28 +29,28 @@ func chatRules(ctx context.Context, s *Session, d *CommandData, t *Table) {
 
 // /new
 func chatNew(ctx context.Context, s *Session, d *CommandData, t *Table) {
-	msg := "If you are looking to \"get into\" the game and spend a lot of time to play with experienced players, the Hyphen-ated group is always looking for more members. To start with, please read the beginners guide, which goes over how we play and how to join our next game: https://github.com/Zamiell/hanabi-conventions/blob/master/Beginner.md"
+	msg := "If you are looking to \"get into\" the game and spend a lot of time to play with experienced players, the Hyphen-ated group is always looking for more members. To start with, please read the beginners guide, which goes over how we play and how to join our next game: https://hanabi.github.io/docs/beginner/"
 	// (we can't put "<" or ">" around the link because then it won't display properly in the lobby)
 	chatServerSend(ctx, msg, d.Room, d.NoTablesLock)
 }
 
 // /doc
 func chatDoc(ctx context.Context, s *Session, d *CommandData, t *Table) {
-	msg := "The strategy reference for the Hyphen-ated group: https://github.com/Zamiell/hanabi-conventions/blob/master/Reference.md"
+	msg := "The strategy reference for the Hyphen-ated group: https://hanabi.github.io/docs/reference/"
 	// (we can't put "<" or ">" around the link because then it won't display properly in the lobby)
 	chatServerSend(ctx, msg, d.Room, d.NoTablesLock)
 }
 
 // /bga
 func chatBGA(ctx context.Context, s *Session, d *CommandData, t *Table) {
-	msg := "If you have experience playing with the Board Game Arena convention framework and you are interested in playing with the Hyphen-ated group, then read this: https://github.com/Zamiell/hanabi-conventions/blob/master/misc/BGA.md"
+	msg := "If you have experience playing with the Board Game Arena convention framework and you are interested in playing with the Hyphen-ated group, then read this: https://github.com/hanabi/hanabi.github.io/blob/main/misc/BGA.md"
 	// (we can't put "<" or ">" around the link because then it won't display properly in the lobby)
 	chatServerSend(ctx, msg, d.Room, d.NoTablesLock)
 }
 
 // /efficiency
 func chatEfficiency(ctx context.Context, s *Session, d *CommandData, t *Table) {
-	msg := "Info on efficiency calculation: https://github.com/Zamiell/hanabi-conventions/blob/master/misc/Efficiency.md"
+	msg := "Info on efficiency calculation: https://github.com/hanabi/hanabi.github.io/blob/main/misc/Efficiency.md"
 	// (we can't put "<" or ">" around the link because then it won't display properly in the lobby)
 	chatServerSend(ctx, msg, d.Room, d.NoTablesLock)
 }


### PR DESCRIPTION
The /new command linked to the old conventions website, this updates the links.