### PR TITLE
Fix lag in throw it in a hole 

### DIFF
--- a/client/src/game/ui/PlayStack.ts
+++ b/client/src/game/ui/PlayStack.ts
@@ -19,47 +19,47 @@ export default class PlayStack extends Konva.Group {
   doLayout(): void {
     const lh = this.height();
 
-    for (const layoutChild of this.children.toArray() as LayoutChild[]) {
-      const scale = lh / layoutChild.height();
-      const stackBase = layoutChild.card.state.rank === STACK_BASE_RANK;
+    const layoutChildren = this.children.toArray() as LayoutChild[];
+    const layoutChild = layoutChildren[layoutChildren.length - 1];
+    const scale = lh / layoutChild.height();
+    const stackBase = layoutChild.card.state.rank === STACK_BASE_RANK;
 
-      // Hide cards in "Throw It in a Hole" variants
-      const opacity =
-        variantRules.isThrowItInAHole(globals.variant) &&
-        globals.state.playing && // Revert to the normal behavior for spectators of ongoing games
-        !globals.state.finished && // Revert to the normal behavior for dedicated replays
-        !stackBase // We want the stack bases to always be visible
-          ? 0
-          : 1;
+    // Hide cards in "Throw It in a Hole" variants
+    const opacity =
+      variantRules.isThrowItInAHole(globals.variant) &&
+      globals.state.playing && // Revert to the normal behavior for spectators of ongoing games
+      !globals.state.finished && // Revert to the normal behavior for dedicated replays
+      !stackBase // We want the stack bases to always be visible
+        ? 0
+        : 1;
 
-      // Animate the card leaving the hand to the play stacks (or vice versa)
-      // (tweening from the hand to the discard pile is handled in the "CardLayout" object)
-      layoutChild.card.startedTweening();
-      layoutChild.card.setRaiseAndShadowOffset();
-      animate(
-        layoutChild,
-        {
-          duration: 0.8,
-          x: 0,
-          y: 0,
-          scale,
-          rotation: 0,
-          opacity,
-          // eslint-disable-next-line @typescript-eslint/unbound-method
-          easing: Konva.Easings.EaseOut,
-          onFinish: () => {
-            if (layoutChild.tween !== null) {
-              layoutChild.tween.destroy();
-              layoutChild.tween = null;
-            }
-            layoutChild.card.finishedTweening();
-            layoutChild.checkSetDraggable();
-            this.hideCardsUnderneathTheTopCard();
-          },
+    // Animate the card leaving the hand to the play stacks (or vice versa)
+    // (tweening from the hand to the discard pile is handled in the "CardLayout" object)
+    layoutChild.card.startedTweening();
+    layoutChild.card.setRaiseAndShadowOffset();
+    animate(
+      layoutChild,
+      {
+        duration: 0.8,
+        x: 0,
+        y: 0,
+        scale,
+        rotation: 0,
+        opacity,
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        easing: Konva.Easings.EaseOut,
+        onFinish: () => {
+          if (layoutChild.tween !== null) {
+            layoutChild.tween.destroy();
+            layoutChild.tween = null;
+          }
+          layoutChild.card.finishedTweening();
+          layoutChild.checkSetDraggable();
+          this.hideCardsUnderneathTheTopCard();
         },
-        true,
-      );
-    }
+      },
+      true,
+    );
   }
 
   hideCardsUnderneathTheTopCard(): void {


### PR DESCRIPTION
Right now when a new card is added to the stack `doLayout` is called, which attempts to animate every card on the stack. This causes insane lag when the play stack is large, which is especially notable in Throw It In A Hole where every card is attached to the same stack object.

I don't see why we can't just animate the most recently played card. 

I tested no variant, TIH, spectator, and replay and everything works fine (and with less lag)
