### PR TITLE
Allow marking cards as critical with notes

### DIFF
--- a/client/src/game/reducers/initialStates/initialState.ts
+++ b/client/src/game/reducers/initialStates/initialState.ts
@@ -43,6 +43,7 @@ export default function initialState(metadata: GameMetadata): State {
         finessed: false,
         blank: false,
         unclued: false,
+        critical: false,
         text: "",
       }),
       allNotes: initArray(totalCards + variant.suits.length + 1, []),

--- a/client/src/game/reducers/notesReducer.ts
+++ b/client/src/game/reducers/notesReducer.ts
@@ -1,6 +1,6 @@
 import produce, { Draft } from "immer";
-import { getVariant } from "../data/gameData";
 import { ensureAllCases } from "../../misc";
+import { getVariant } from "../data/gameData";
 import { NoteAction } from "../types/actions";
 import CardNote from "../types/CardNote";
 import GameMetadata from "../types/GameMetadata";
@@ -153,6 +153,7 @@ function parseNote(variant: Variant, text: string): CardNote {
   );
   const blank = checkNoteKeywordsForMatch(["blank"], keywords);
   const unclued = checkNoteKeywordsForMatch(["unclued"], keywords);
+  const critical = checkNoteKeywordsForMatch(["critical", "crit"], keywords);
 
   return {
     possibilities,
@@ -162,6 +163,7 @@ function parseNote(variant: Variant, text: string): CardNote {
     needsFix,
     blank,
     unclued,
+    critical,
     text,
   };
 }

--- a/client/src/game/types/CardNote.ts
+++ b/client/src/game/types/CardNote.ts
@@ -7,5 +7,6 @@ export default interface CardNote {
   readonly finessed: boolean;
   readonly blank: boolean;
   readonly unclued: boolean;
+  readonly critical: boolean;
   readonly text: string;
 }

--- a/client/src/game/ui/HanabiCard.ts
+++ b/client/src/game/ui/HanabiCard.ts
@@ -813,11 +813,14 @@ export default class HanabiCard extends Konva.Group implements NodeWithTooltip {
   }
 
   private shouldSetCritical(critical: boolean) {
+    // use the critical note if it's on another player's card
     return (
-      critical &&
-      !cardRules.isPlayed(this.state) &&
-      !cardRules.isDiscarded(this.state) &&
-      !globals.lobby.settings.realLifeMode
+      (this.note.critical &&
+        this.state.location !== globals.metadata.ourPlayerIndex) ||
+      (critical &&
+        !cardRules.isPlayed(this.state) &&
+        !cardRules.isDiscarded(this.state) &&
+        !globals.lobby.settings.realLifeMode)
     );
   }
 


### PR DESCRIPTION
This would be useful for throw it in a hole when Alice misplays a card and Bob wants to mark the other copy in Cathy's hand as critical.

I wrote it such that it only works on other people's cards.