### PR TITLE
Fixing notes issues (#2097 and #2098) with throw it in a hole.

### DIFF
--- a/client/src/game/ui/drawUI.ts
+++ b/client/src/game/ui/drawUI.ts
@@ -330,6 +330,22 @@ function drawPlayStacks() {
     playStackValues.x += (cardWidth + playStackValues.spacing) * 1.5;
   }
 
+  // Make the invisible "hole" play stack for "Throw It in a Hole" variants
+  // (centered in the middle of the rest of the stacks)
+  if (variantRules.isThrowItInAHole(globals.variant) && globals.state.playing) {
+    const playStackX =
+      playStackValues.x + playStackValues.w / 2 - cardWidth / 2;
+    const playStack = new PlayStack({
+      x: playStackX * winW,
+      y: playStackValues.y * winH,
+      width: cardWidth * winW,
+      height: cardHeight * winH,
+      listening: false,
+    });
+    globals.elements.playStacks.set("hole", playStack);
+    globals.layers.card.add((playStack as unknown) as Konva.Group);
+  }
+
   for (let i = 0; i < globals.variant.suits.length; i++) {
     const suit = globals.variant.suits[i];
 
@@ -395,22 +411,6 @@ function drawPlayStacks() {
       globals.layers.UI.add(suitLabelText);
       globals.elements.suitLabelTexts.push(suitLabelText);
     }
-  }
-
-  // Make the invisible "hole" play stack for "Throw It in a Hole" variants
-  // (centered in the middle of the rest of the stacks)
-  if (variantRules.isThrowItInAHole(globals.variant) && globals.state.playing) {
-    const playStackX =
-      playStackValues.x + playStackValues.w / 2 - cardWidth / 2;
-    const playStack = new PlayStack({
-      x: playStackX * winW,
-      y: playStackValues.y * winH,
-      width: cardWidth * winW,
-      height: cardHeight * winH,
-      listening: false,
-    });
-    globals.elements.playStacks.set("hole", playStack);
-    globals.layers.card.add((playStack as unknown) as Konva.Group);
   }
 
   // This is the invisible rectangle that players drag cards to in order to play them

--- a/client/src/game/ui/reactive/StateObserver.ts
+++ b/client/src/game/ui/reactive/StateObserver.ts
@@ -390,6 +390,14 @@ const replayObservers: Subscriptions = [
     }),
     cardsView.onMorphedIdentitiesChanged,
   ),
+
+  // Remove notes morph from play stacks after game finishes
+  subAfterInit(
+    (s) => ({
+      finished: s.finished,
+    }),
+    cardLayoutView.updatePlayStackVisuals,
+  ),
 ];
 
 const otherObservers = [

--- a/client/src/game/ui/reactive/view/cardLayoutView.ts
+++ b/client/src/game/ui/reactive/view/cardLayoutView.ts
@@ -1,11 +1,13 @@
 import equal from "fast-deep-equal";
 import Konva from "konva";
 import { variantRules } from "../../../rules";
+import * as deck from "../../../rules/deck";
 import { STACK_BASE_RANK } from "../../../types/constants";
 import StackDirection from "../../../types/StackDirection";
 import globals from "../../globals";
 import HanabiCard from "../../HanabiCard";
 import LayoutChild from "../../LayoutChild";
+import { updateCardVisuals } from "./cardsView";
 
 const stackStringsReversed = new Map<StackDirection, string>([
   [StackDirection.Undecided, ""],
@@ -140,6 +142,13 @@ export function onHoleChanged(
   );
 
   globals.layers.card.batchDraw();
+}
+
+export function updatePlayStackVisuals(): void {
+  const totalCards: number = deck.totalCards(globals.variant);
+  for (let i = 0; i < globals.variant.suits.length; i++) {
+    updateCardVisuals(totalCards + i);
+  }
 }
 
 function syncChildren(

--- a/client/src/game/ui/reactive/view/cardsView.ts
+++ b/client/src/game/ui/reactive/view/cardsView.ts
@@ -197,7 +197,7 @@ function updatePips(order: number) {
   globals.layers.card.batchDraw();
 }
 
-function updateCardVisuals(order: number) {
+export function updateCardVisuals(order: number): void {
   const card = getCardOrStackBase(order);
   card.setBareImage();
   globals.layers.card.batchDraw();


### PR DESCRIPTION
#2097 : Unmorphing play stacks at game end by adding a new observer on the "finished" property.
#2098 : Allowing notes on a middle play stack after someone plays a card by creating the invisible "hole" play stack before the regular play stacks, so the "hole" will be behind the middle play stack as opposed to in front of it (so it won't block notes anymore).