### PR TITLE
Fix: make date&time column sortable closes #2130

### DIFF
--- a/server/src/views/history.tmpl
+++ b/server/src/views/history.tmpl
@@ -74,7 +74,7 @@
       <th># of Players</th>
       <th>Score</th>
       <th>Variant</th>
-      <th>Date & Time</th>
+      <th class="sorter-date-and-time">Date & Time</th>
       <th>Players</th>
       {{if not .SpecificSeed}}<th>Other Scores</th>{{end}}
       {{if eq .Title "Tagged Games" }}<th>Tags</th>{{end}}

--- a/server/src/views/profile.tmpl
+++ b/server/src/views/profile.tmpl
@@ -99,6 +99,26 @@
       ],
     });
 
+    // Add parser for date and time column to enable sorting
+    // https://mottie.github.io/tablesorter/docs/example-parsers.html
+    $.tablesorter.addParser({
+      id: 'date-and-time', // matches all table header cells with class "sorter-date-and-time"
+      is: function (s, table, cell, $cell) {
+        // return false so this parser is not auto detected
+        return false;
+      },
+      format: function (s, table, cell, cellIndex) {
+        // s is the date and time string
+        // format "YYYY-MM-DD — hh:mm:ss Z", e.g. "2021-03-14 — 16:33:05 UTC"
+        // parsing the date and time string (regex), converting it to a date and then to unix timestamp/seconds
+        const regexDateAndTime = new RegExp(`(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2}) — (?<hours>\\d{2}):(?<minutes>\\d{2}):(?<seconds>\\d{2})`);
+        const d = regexDateAndTime.exec(s).groups;
+        const time = (new Date(d.year, d.month - 1, d.day, d.hours, d.minutes, d.seconds)).getTime();
+        return time;
+      },
+      type: 'numeric'
+    });
+
     // Initialize the table sorting
     $('table').tablesorter();
 

--- a/server/src/views/profile.tmpl
+++ b/server/src/views/profile.tmpl
@@ -111,10 +111,15 @@
         // s is the date and time string
         // format "YYYY-MM-DD — hh:mm:ss Z", e.g. "2021-03-14 — 16:33:05 UTC"
         // parsing the date and time string (regex), converting it to a date and then to unix timestamp/seconds
-        const regexDateAndTime = new RegExp(`(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2}) — (?<hours>\\d{2}):(?<minutes>\\d{2}):(?<seconds>\\d{2})`);
-        const d = regexDateAndTime.exec(s).groups;
-        const time = (new Date(d.year, d.month - 1, d.day, d.hours, d.minutes, d.seconds)).getTime();
-        return time;
+        try {
+          const regexDateAndTime = new RegExp(`(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2}) — (?<hours>\\d{2}):(?<minutes>\\d{2}):(?<seconds>\\d{2})`);
+          const d = regexDateAndTime.exec(s).groups;
+          const time = (new Date(d.year, d.month - 1, d.day, d.hours, d.minutes, d.seconds)).getTime();
+          return time;
+        } catch {
+          // date and time string was not in expected format
+          return 0;
+        }
       },
       type: 'numeric'
     });


### PR DESCRIPTION
To fix the issue described in #2130, I just needed to tell the tablesorter plugin how to parse the date and time values in this column. As explained in the comments, my current fix assumes that the displayed date and time is always in the format `YYYY-MM-DD — hh:mm:ss`. Based on my observation this is true for my local tests as well as for the official website. But I do not know whether this is implicitly (Go/Postgres/...?) or specified somewhere (I didn't found something corresponding). If the date and time string is in another format, sorting will not work (order as returned from backend; behavior is exactly the same as in current productive version).

What do you think? Is there a possibility that the date and time string will have another format? Is this fine or do you have any idea for a more generic approach?