### PR TITLE
[client] set focus to close button, closes with [ENTER]

### DIFF
--- a/client/src/globals.ts
+++ b/client/src/globals.ts
@@ -53,6 +53,8 @@ export class Globals {
   ui: HanabiUI | null = null;
   // Used to keep track of how many in-game chat messages are currently unread
   chatUnread = 0;
+  // Used to keep track of the active element before model warning box
+  lastActiveElement: HTMLElement | null = null;
 
   browserIsFirefox = navigator.userAgent.toLowerCase().indexOf("firefox") > -1;
 }

--- a/client/src/modals.ts
+++ b/client/src/modals.ts
@@ -88,7 +88,14 @@ export function warningShow(msg: string): void {
   globals.modalShowing = true;
 
   $("#warning-modal-description").html(msg);
-  $("#warning-modal").fadeIn(FADE_TIME);
+
+  // store the screen's active element
+  globals.lastActiveElement = document.activeElement as HTMLElement;
+
+  // show the modal and focus the close button
+  $("#warning-modal").fadeIn(FADE_TIME, () => {
+    $("#warning-modal-button").focus();
+  });
 }
 
 export function errorShow(msg: string): void {
@@ -139,6 +146,9 @@ export function setShadeOpacity(
 function warningClose() {
   $("#warning-modal").fadeOut(FADE_TIME);
   setShadeOpacity(0, false);
+  if (globals.lastActiveElement) {
+    globals.lastActiveElement.focus();
+  }
 }
 
 export function closeAll(): void {

--- a/client/src/modals.ts
+++ b/client/src/modals.ts
@@ -89,10 +89,10 @@ export function warningShow(msg: string): void {
 
   $("#warning-modal-description").html(msg);
 
-  // store the screen's active element
+  // Store the screen's active element
   globals.lastActiveElement = document.activeElement as HTMLElement;
 
-  // show the modal and focus the close button
+  // Show the modal and focus the close button
   $("#warning-modal").fadeIn(FADE_TIME, () => {
     $("#warning-modal-button").focus();
   });


### PR DESCRIPTION
When the user types an invalid command, a modal warning is shown. This fix moves the focus to the "close" button, which can now be closed by pressing ENTER.

After modal close, the focus is set to the last HTML element, which is the appropriate text box.