### PR TITLE
Fix #2065

### DIFF
--- a/client/src/chat.ts
+++ b/client/src/chat.ts
@@ -31,6 +31,7 @@ const serverSideOnlyCommands = [
   "document",
   "reference",
   "efficiency",
+  "replay",
   "random",
   "uptime",
   "timeleft",


### PR DESCRIPTION
One line change to add the replay command to the client. 

The replay command is already supported server-side, but a client-side check was blocking it from being sent. Added "replay" to the command whitelist to account for this.

Fixes #2065