### PR TITLE
Make hard variant and low score phase indicators colorblind friendly

### DIFF
--- a/client/src/game/ui/drawUI.ts
+++ b/client/src/game/ui/drawUI.ts
@@ -1434,6 +1434,12 @@ function drawStatistics() {
       globals.lobby.settings.hyphenatedConventions
         ? "#ffb2b2"
         : LABEL_COLOR,
+    // Ïf colorblindMode is activated, indicate make font bold if "Hard"
+    fontStyle :
+      globals.metadata.hardVariant &&
+      globals.lobby.settings.hyphenatedConventions &&
+      globals.lobby.settings.colorblindMode
+        ? 'bold' : 'normal',
     listening: true,
   }) as Konva.Text;
   globals.layers.UI.add(efficiencyMinNeededLabel);

--- a/client/src/game/ui/drawUI.ts
+++ b/client/src/game/ui/drawUI.ts
@@ -1434,12 +1434,13 @@ function drawStatistics() {
       globals.lobby.settings.hyphenatedConventions
         ? "#ffb2b2"
         : LABEL_COLOR,
-    // Ïf colorblindMode is activated, indicate make font bold if "Hard"
-    fontStyle :
+    // If colorblindMode is activated, indicate make font bold if "Hard"
+    fontStyle:
       globals.metadata.hardVariant &&
       globals.lobby.settings.hyphenatedConventions &&
       globals.lobby.settings.colorblindMode
-        ? 'bold' : 'normal',
+        ? "bold"
+        : "normal",
     listening: true,
   }) as Konva.Text;
   globals.layers.UI.add(efficiencyMinNeededLabel);

--- a/client/src/game/ui/reactive/view/gameInfoView.ts
+++ b/client/src/game/ui/reactive/view/gameInfoView.ts
@@ -94,9 +94,12 @@ export function onScoreOrMaxScoreChanged(data: {
     lowScorePhase && globals.lobby.settings.hyphenatedConventions
       ? "cyan"
       : LABEL_COLOR;
-  if (lowScorePhase && globals.lobby.settings.hyphenatedConventions &&
-      globals.lobby.settings.colorblindMode) {
-    scoreLabel.fontStyle('bold');
+  if (
+    lowScorePhase &&
+    globals.lobby.settings.hyphenatedConventions &&
+    globals.lobby.settings.colorblindMode
+  ) {
+    scoreLabel.fontStyle("bold");
   }
   scoreLabel.fill(scoreLabelColor);
 

--- a/client/src/game/ui/reactive/view/gameInfoView.ts
+++ b/client/src/game/ui/reactive/view/gameInfoView.ts
@@ -94,6 +94,10 @@ export function onScoreOrMaxScoreChanged(data: {
     lowScorePhase && globals.lobby.settings.hyphenatedConventions
       ? "cyan"
       : LABEL_COLOR;
+  if (lowScorePhase && globals.lobby.settings.hyphenatedConventions &&
+      globals.lobby.settings.colorblindMode) {
+    scoreLabel.fontStyle('bold');
+  }
   scoreLabel.fill(scoreLabelColor);
 
   // Reposition the maximum score


### PR DESCRIPTION
When a variant is hard or it's the low score phase, the numbers of the corresponding info are colored.
This PR makes the font also bold if colorblind mode is activated.

![colorblind](https://user-images.githubusercontent.com/83447589/117863029-9b472600-b293-11eb-8e0b-754dd4a6f1cb.png)
