### PR TITLE
Fix verification if chat needs to scroll

### DIFF
--- a/client/src/chat.ts
+++ b/client/src/chat.ts
@@ -595,13 +595,10 @@ export function add(data: ChatMessage, fast: boolean): void {
   // Find out if we should automatically scroll down after adding the new line of chat
   // https://stackoverflow.com/questions/6271237/detecting-when-user-scrolls-to-bottom-of-div-with-jquery
   // If we are already scrolled to the bottom, then it is ok to automatically scroll
-  // scrollTop can be a fractional value for some reason,
-  // so we need to check both the floor and the ceiling for this to work properly
-  const autoScroll =
-    chat[0].scrollHeight - Math.floor(chat[0].scrollTop) ===
-      chat[0].clientHeight ||
-    chat[0].scrollHeight - Math.ceil(chat[0].scrollTop) ===
-      chat[0].clientHeight;
+  // scrollTop can be a fractional value for some reason.
+  // pxEpsilon is an acceptable range defined in pixels e.g. +-2 px
+  const pxEpsilon = 2;
+  const autoScroll = Math.abs(chat[0].clientHeight + chat[0].scrollTop - chat[0].scrollHeight) < pxEpsilon;
 
   // Add the new line and fade it in
   chat.append(line);


### PR DESCRIPTION
I encountered this issue with the auto-scroll:

https://user-images.githubusercontent.com/86917256/124386937-a25b4500-dcd4-11eb-905d-dd5fd4990aaa.mov

It happens only when my browser window is not in full-screen and it fixes itself if I refresh the page. I'm on a MacOS 11.3.1
This could be the issue described in #2078

Basically I noticed that the `scrollHeight - scrollTop` value is 1px bigger than `clientHeight` and it causes the issue. I'm not sure where this pixel comes from (I initially thought it might be the border since it's 1px wide but it's not) so I decided to give it a +-2 px margin to decide if it should auto-scroll. This way it will also work when `scrollTop` is fractional sometimes.

Note: I didn't manage to test this change locally
