### PR TITLE
Fix score being permanently bold in colorblind mode

### DIFF
--- a/client/src/game/ui/reactive/view/gameInfoView.ts
+++ b/client/src/game/ui/reactive/view/gameInfoView.ts
@@ -94,13 +94,13 @@ export function onScoreOrMaxScoreChanged(data: {
     lowScorePhase && globals.lobby.settings.hyphenatedConventions
       ? "cyan"
       : LABEL_COLOR;
-  if (
+  const scoreLabelStyle =
     lowScorePhase &&
     globals.lobby.settings.hyphenatedConventions &&
     globals.lobby.settings.colorblindMode
-  ) {
-    scoreLabel.fontStyle("bold");
-  }
+      ? "bold"
+      : "normal";
+  scoreLabel.fontStyle(scoreLabelStyle);
   scoreLabel.fill(scoreLabelColor);
 
   // Reposition the maximum score


### PR DESCRIPTION
Fixes (me-made) bug were score is always bold in colorblind mode, instead of being bold only during low score phase.