### PR TITLE
Notes editing on mobile

### DIFF
--- a/client/src/game/ui/HanabiCardMouse.ts
+++ b/client/src/game/ui/HanabiCardMouse.ts
@@ -76,8 +76,13 @@ function touchStart(
     // A tap will trigger when the "touchend" event occurs
     // The next tap action will not run because it will appear like the second tap of a double tap
     // Don't worry about this if we actually double-tapped
-    if (!this.wasRecentlyTapped && globals.editingNote === null) {
+    if (!this.wasRecentlyTapped) {
       this.wasRecentlyTapped = true;
+    }
+    if (globals.editingNote !== null) {
+      const tooltip = $(`#tooltip-${this.tooltipName}`);
+      globals.editingNote = null;
+      tooltip.tooltipster("close");
     }
   }, DOUBLE_TAP_DELAY);
 

--- a/client/src/game/ui/HanabiCardTouchActions.ts
+++ b/client/src/game/ui/HanabiCardTouchActions.ts
@@ -59,5 +59,7 @@ export function HanabiCardDblTap(this: HanabiCard): void {
     return;
   }
 
-  notes.openEditTooltip(this);
+  // open notes from mobile
+  const isDesktop = false;
+  notes.openEditTooltip(this, isDesktop);
 }

--- a/client/src/game/ui/notes.ts
+++ b/client/src/game/ui/notes.ts
@@ -116,7 +116,7 @@ export function show(card: HanabiCard): void {
   tooltip.tooltipster("open");
 }
 
-export function openEditTooltip(card: HanabiCard): void {
+export function openEditTooltip(card: HanabiCard, isDesktop = true): void {
   // Don't edit any notes in dedicated replays
   if (globals.state.finished) {
     return;
@@ -134,9 +134,10 @@ export function openEditTooltip(card: HanabiCard): void {
   // the "focusout" handler will automatically close the tooltip,
   // but then this code will run and immediately re-open the tooltip
   // Detect if this is happening and do nothing
+  // The "focusout" event does not fire on mobile, therefore we only check for desktop clients.
   const tooltip = $(`#tooltip-${card.tooltipName}`);
   const status = tooltip.tooltipster("status");
-  if (status.state === "disappearing") {
+  if (isDesktop && status.state === "disappearing") {
     return;
   }
 


### PR DESCRIPTION
Double tap to redit note, click on the same card to close the note.

Desktop behaviour is unaffected (right click opens/closes the note)