### PR TITLE
Focus the Change Variant when game options shown

### DIFF
--- a/client/src/lobby/createGame.ts
+++ b/client/src/lobby/createGame.ts
@@ -531,10 +531,10 @@ export function ready(): void {
   $("#create-game-submit").text(buttonTitle);
   $("#createTableName").val(gameName);
 
-  // Focus the "Name" box
+  // Focus the Change Variant dropdown
   // (this has to be in a callback in order to work)
   setTimeout(() => {
-    $("#createTableName").focus();
+    $("#create-game-variant-dropdown1").trigger("focus");
   }, 0);
 
   // Fill in the rest of form with the settings that we used last time


### PR DESCRIPTION
Currently the game's name control has the focus when options are shown. I believe it's much more useful to set the focus to the change variant control, since it's the one changed most often.