### PR TITLE
Fix table creation commands

### DIFF
--- a/server/src/command_table_create.go
+++ b/server/src/command_table_create.go
@@ -59,7 +59,7 @@ func commandTableCreate(ctx context.Context, s *Session, d *CommandData) {
 
 	var message string
 	// Check for valid name
-	isValid, message := isTableNameValid(d.Name, d.GameJSON == nil)
+	isValid, message := isTableNameValid(d.Name, false)
 	if !isValid {
 		s.Warning(message)
 		return


### PR DESCRIPTION
This PR disables exclamation mark validation when calling `isTableNameValid` from table_create because it was falsely invalidating any table name starting with an exclamation mark. The purpose of the validation is still fulfilled by code later in the function.