### PR TITLE
Server restart also sent to website-dev channel

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -53,6 +53,7 @@ DISCORD_TOKEN=
 # A guild is the internal name for a server
 DISCORD_GUILD_ID=
 DISCORD_CHANNEL_SYNC_WITH_LOBBY=
+DISCORD_CHANNEL_WEBSITE_DEVELOPMENT=
 
 # Information for GitHub repository automation
 # If blank, GitHub functionality will not be used

--- a/server/src/command_chat.go
+++ b/server/src/command_chat.go
@@ -140,6 +140,12 @@ func chat(ctx context.Context, s *Session, d *CommandData, userID int, rawMsg st
 		// We use "rawMsg" instead of "d.Msg" because we want to send the unescaped message
 		// (since Discord can handle escaping HTML special characters itself)
 		discordSend(discordChannelSyncWithLobby, d.Username, rawMsg)
+
+		// Some messages are also sent to website-development
+		if sendMessageToWebDevChannel {
+			discordSend(discordChannelWebsiteDev, d.Username, rawMsg)
+			sendMessageToWebDevChannel = false
+		}
 	}
 
 	// Check for commands

--- a/server/src/discord.go
+++ b/server/src/discord.go
@@ -14,6 +14,8 @@ var (
 	discordToken                string
 	discordGuildID              string
 	discordChannelSyncWithLobby string
+	discordChannelWebsiteDev    string
+	sendMessageToWebDevChannel  bool
 	discordBotID                string
 	discordIsReady              = abool.New()
 )
@@ -43,6 +45,14 @@ func discordInit() {
 			"aborting Discord initialization.")
 		return
 	}
+	discordChannelWebsiteDev = os.Getenv("DISCORD_CHANNEL_WEBSITE_DEVELOPMENT")
+	if len(discordChannelWebsiteDev) == 0 {
+		logger.Info("The \"DISCORD_CHANNEL_WEBSITE_DEVELOPMENT\" environment variable is blank; " +
+			"aborting Discord initialization.")
+		return
+	}
+	// Messages are only sent to website-development channel when the server restarts
+	sendMessageToWebDevChannel = false
 
 	// Initialize the command map
 	discordCommandInit()
@@ -76,6 +86,8 @@ func discordConnect() {
 	// (we wait for Discord to connect before displaying this message)
 	msg := "The server has successfully started at: " + getCurrentTimestamp() + " " +
 		"(" + gitCommitOnStart + ")"
+	// Send once this message to website-development as well
+	sendMessageToWebDevChannel = true
 	chatServerSend(ctx, msg, "lobby", false)
 }
 


### PR DESCRIPTION
Closes #1957

1. **Untested** (but it should work properly)
2. Before server restart, .env must be filled in with the new value
