### PR TITLE
Max players change option

### DIFF
--- a/client/src/lobby/createGame.ts
+++ b/client/src/lobby/createGame.ts
@@ -355,6 +355,7 @@ function submit() {
       tableID: globals.tableID,
       name,
       options,
+      maxPlayers,
     });
   }
 
@@ -367,11 +368,13 @@ function submit() {
 
 function acceptOptionsFromGuest(options: Options) {
   const name = options.tableName;
+  const maxPlayers = options.maxPlayers;
 
   globals.conn!.send("tableUpdate", {
     tableID: globals.tableID,
     name,
     options,
+    maxPlayers,
   });
 }
 

--- a/client/src/lobby/createGame.ts
+++ b/client/src/lobby/createGame.ts
@@ -303,6 +303,7 @@ function submit() {
   if (maxPlayers < 2 || maxPlayers > 6) {
     maxPlayers = 5;
   }
+  localStorage.setItem("createTableMaxPlayers", maxPlayers.toString());
 
   // Game JSON is not saved
   const gameJSONString = $("#createTableJSON").val();

--- a/client/src/lobby/createGame.ts
+++ b/client/src/lobby/createGame.ts
@@ -303,7 +303,7 @@ function submit() {
   if (maxPlayers < 2 || maxPlayers > 6) {
     maxPlayers = 5;
   }
-  localStorage.setItem("createTableMaxPlayers", maxPlayers.toString());
+  checkChanged("createTableMaxPlayers", maxPlayers);
 
   // Game JSON is not saved
   const gameJSONString = $("#createTableJSON").val();
@@ -585,15 +585,12 @@ export function ready(): void {
     $("#createTablePassword").val(password);
   }
 
-  const maxPlayers = localStorage.getItem("createTableMaxPlayers");
-  let max = 5;
-  if (maxPlayers !== null) {
-    max = parseIntSafe(maxPlayers);
-    if (Number.isNaN(max) || max < 2 || max > 6) {
-      max = 5;
-    }
+  let maxPlayers = globals.settings.createTableMaxPlayers;
+  console.log(maxPlayers);
+  if (maxPlayers < 2 || maxPlayers > 6) {
+    maxPlayers = 5;
   }
-  $("#createTableMaxPlayers").val(max);
+  $("#createTableMaxPlayers").val(maxPlayers);
 
   // Hide the extra options if we do not have any selected
   if (

--- a/client/src/lobby/createGame.ts
+++ b/client/src/lobby/createGame.ts
@@ -586,7 +586,6 @@ export function ready(): void {
   }
 
   let maxPlayers = globals.settings.createTableMaxPlayers;
-  console.log(maxPlayers);
   if (maxPlayers < 2 || maxPlayers > 6) {
     maxPlayers = 5;
   }

--- a/client/src/lobby/createGame.ts
+++ b/client/src/lobby/createGame.ts
@@ -581,6 +581,16 @@ export function ready(): void {
     $("#createTablePassword").val(password);
   }
 
+  const maxPlayers = localStorage.getItem("createTableMaxPlayers");
+  let max = 5;
+  if (maxPlayers !== null) {
+    max = parseIntSafe(maxPlayers);
+    if (Number.isNaN(max) || max < 2 || max > 6) {
+      max = 5;
+    }
+  }
+  $("#createTableMaxPlayers").val(max);
+
   // Hide the extra options if we do not have any selected
   if (
     !globals.settings.createTableSpeedrun &&

--- a/client/src/lobby/types/Settings.ts
+++ b/client/src/lobby/types/Settings.ts
@@ -26,4 +26,5 @@ export default class Settings {
   createTableOneLessCard = false;
   createTableAllOrNothing = false;
   createTableDetrimentalCharacters = false;
+  createTableMaxPlayers = 5;
 }

--- a/client/src/types/Options.ts
+++ b/client/src/types/Options.ts
@@ -16,6 +16,7 @@ export default class Options {
   readonly allOrNothing: boolean = false;
   readonly detrimentalCharacters: boolean = false;
   readonly tableName?: string;
+  readonly maxPlayers?: number;
 }
 
 export const OptionIcons = {

--- a/install/database_schema.sql
+++ b/install/database_schema.sql
@@ -73,6 +73,7 @@ CREATE TABLE user_settings (
     create_table_one_less_card           BOOLEAN   NOT NULL  DEFAULT FALSE,
     create_table_all_or_nothing          BOOLEAN   NOT NULL  DEFAULT FALSE,
     create_table_detrimental_characters  BOOLEAN   NOT NULL  DEFAULT FALSE,
+    create_table_max_players             INTEGER   NOT NULL  DEFAULT 5,
     FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
 );
 

--- a/server/src/command_replay_create.go
+++ b/server/src/command_replay_create.go
@@ -534,6 +534,7 @@ func loadJSONOptionsToTable(d *CommandData, t *Table) {
 		AllOrNothing:          allOrNothing,
 		DetrimentalCharacters: detrimentalCharacters,
 		TableName:             "",
+		MaxPlayers:            0,
 	}
 	t.ExtraOptions = &ExtraOptions{
 		// Normally, "DatabaseID" is set to either -1 (in an ongoing game)

--- a/server/src/misc.go
+++ b/server/src/misc.go
@@ -151,6 +151,15 @@ func max(x, y int) int {
 	return y
 }
 
+// Ensures a number is between limits.
+// Returns that number or the default value
+func between(x, minimum, maximum, defaultValue int) int {
+	if x < minimum || x > maximum {
+		return defaultValue
+	}
+	return x
+}
+
 func normalizeString(str string) string {
 	// First, we transliterate the string to pure ASCII
 	// Second, we lowercase it

--- a/server/src/models_user_settings.go
+++ b/server/src/models_user_settings.go
@@ -35,6 +35,7 @@ type Settings struct {
 	CreateTableOneLessCard           bool    `json:"createTableOneLessCard"`
 	CreateTableAllOrNothing          bool    `json:"createTableAllOrNothing"`
 	CreateTableDetrimentalCharacters bool    `json:"createTableDetrimentalCharacters"`
+	CreateTableMaxPlayers            int     `json:"createTableMaxPlayers"`
 }
 
 var (
@@ -79,7 +80,8 @@ func (*UserSettings) Get(userID int) (Settings, error) {
 			create_table_one_extra_card,
 			create_table_one_less_card,
 			create_table_all_or_nothing,
-			create_table_detrimental_characters
+			create_table_detrimental_characters,
+			create_table_max_players
 		FROM user_settings
 		WHERE user_id = $1
 	`, userID).Scan(
@@ -108,6 +110,7 @@ func (*UserSettings) Get(userID int) (Settings, error) {
 		&settings.CreateTableOneLessCard,
 		&settings.CreateTableAllOrNothing,
 		&settings.CreateTableDetrimentalCharacters,
+		&settings.CreateTableMaxPlayers,
 	); errors.Is(err, pgx.ErrNoRows) {
 		return defaultSettings, nil
 	} else if err != nil {

--- a/server/src/options.go
+++ b/server/src/options.go
@@ -21,6 +21,7 @@ type Options struct {
 	AllOrNothing          bool   `json:"allOrNothing"`
 	DetrimentalCharacters bool   `json:"detrimentalCharacters"`
 	TableName             string `json:"tableName,omitempty"`
+	MaxPlayers            int    `json:"maxPlayers,omitempty"`
 }
 
 // ExtraOptions are extra specifications for the game; they are not recorded in the database

--- a/server/src/options.go
+++ b/server/src/options.go
@@ -85,6 +85,7 @@ func NewOptions() *Options {
 		AllOrNothing:          false,
 		DetrimentalCharacters: false,
 		TableName:             "",
+		MaxPlayers:            0,
 	}
 }
 


### PR DESCRIPTION
- Max players is now saved in local storage
- During pregame, host can change the max number of players
- During pregame, guests can propose new max players (warning if this is less than the number present ones)
- If new value of Max Players is less than the number present players, extra players are kicked with a message.