### PR TITLE
Correctly identify card for empathy cancel

### DIFF
--- a/client/src/game/ui/HanabiCardMouse.ts
+++ b/client/src/game/ui/HanabiCardMouse.ts
@@ -381,7 +381,7 @@ function checkForHypoEmpathy(card: HanabiCard): boolean {
       const child =
         globals.elements.playerHands[startingPlayerIndex!].children[i];
       const currentCard: HanabiCard = child.children[0] as HanabiCard;
-      if (currentCard.id === card.id) {
+      if (currentCard._id === card._id) {
         return true;
       }
     }


### PR DESCRIPTION
Unrelated to latest issue, but still a bug, fixed now.

HanabiCard.id (inherited from Konva.Group) returns a function, not a value.