### PR TITLE
Return more variants information in a separate API endpoint

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -560,7 +560,8 @@ In-game, the right side of the screen shows the _Pace_ and the _Efficiency_ for 
 | URL                                           | Description                                                                                                 |
 | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | `/export/[game ID]`                           | Provides the data for an arbitrary game from the database.                                                  |
-| `/api/v1/variants`                            | Displays a paginated list of variants and their IDs.                                                        |
+| `/api/v1/variants`                            | Displays a list of variants and their IDs.                                                                  |
+| `/api/v1/variants-full`                       | Displays a list of variants information and their IDs.                                                      |
 | `/api/v1/variants/[variant ID]`               | Displays a paginated list of games played in that specific variant.                                         |
 | `/api/v1/history/[username]`                  | Lists a paginated list of the player's past games.                                                          |
 | `/api/v1/history/[username]/[username2]`      | Lists a paginated list of past games where the players were in together. (You can specify up to 6 players.) |

--- a/server/src/api_misc.go
+++ b/server/src/api_misc.go
@@ -161,6 +161,9 @@ func apiSetRoutes(httpRouter *gin.Engine) {
 	// List of variants available
 	httpRouter.GET(api+"/variants", apiVariants)
 
+	// List of variants available, with more info
+	httpRouter.GET(api+"/variants-full", apiVariantsFull)
+
 	// List of games by variant
 	httpRouter.GET(api+"/variants/:id", apiVariantsSingle)
 

--- a/server/src/api_variants.go
+++ b/server/src/api_variants.go
@@ -27,15 +27,30 @@ type APIVariantAnswer struct {
 // List of variants
 //   /api/v1/variants
 //
-//   Columns
-//   id   int
-//   name string
+//   A map from variant id to variant name (string)
 func apiVariants(c *gin.Context) {
 	if apiCheckIPBanned(c) {
 		return
 	}
 
 	c.JSON(http.StatusOK, variantIDMap)
+}
+
+// List of variants, with more info
+//   /api/v1/variants-full
+//
+//   A map from variant id to variant info. Variant info has these columns:
+//
+//   name       string
+//   suits      string[]
+//   stackSize  int
+//   maxScore   int
+func apiVariantsFull(c *gin.Context) {
+	if apiCheckIPBanned(c) {
+		return
+	}
+
+	c.JSON(http.StatusOK, variantIDFullMap)
 }
 
 // Returns list of games of given variant

--- a/server/src/variants.go
+++ b/server/src/variants.go
@@ -9,11 +9,12 @@ import (
 )
 
 var (
-	variants     map[string]*Variant
-	variantIDMap map[int]string
-	variantNames []string
-	oddClues     []int
-	evenClues    []int
+	variants         map[string]*Variant
+	variantIDMap     map[int]string
+	variantIDFullMap map[int]VariantInfoJSON
+	variantNames     []string
+	oddClues         []int
+	evenClues        []int
 )
 
 // VariantJSON is very similar to Variant,
@@ -41,6 +42,14 @@ type VariantJSON struct {
 	UpOrDown                 bool      `json:"upOrDown"`
 }
 
+// VariantInfoJSON contains limited information about a variant, returned in /api/v1/variants-full
+type VariantInfoJSON struct {
+	Name      string   `json:"name"`
+	Suits     []string `json:"suits"`
+	StackSize int      `json:"stackSize"`
+	MaxScore  int      `json:"maxScore"`
+}
+
 func variantsInit() {
 	// Import the JSON file
 	filePath := path.Join(jsonPath, "variants.json")
@@ -60,6 +69,7 @@ func variantsInit() {
 	// Convert the array to a map
 	variants = make(map[string]*Variant)
 	variantIDMap = make(map[int]string)
+	variantIDFullMap = make(map[int]VariantInfoJSON)
 	variantNames = make([]string, 0)
 	for _, variant := range variantsArray {
 		// Validate the name
@@ -189,6 +199,12 @@ func variantsInit() {
 			return
 		}
 		variantIDMap[variant.ID] = variant.Name
+		variantIDFullMap[variant.ID] = VariantInfoJSON{
+			Name:      variant.Name,
+			Suits:     variant.Suits,
+			StackSize: stackSize,
+			MaxScore:  len(variantSuits) * stackSize,
+		}
 
 		// Create an array with every variant name
 		variantNames = append(variantNames, variant.Name)


### PR DESCRIPTION
Addresses https://github.com/Hanabi-Live/hanabi-live/issues/2922.

In this PR, just return the most basic information about each variant. If more information is requested, it should be easy to add later.

Snippets of the response from `/api/v1/variants-full`:

```
{
  "0": {
    "name": "No Variant",
    "suits": [
      "Red",
      "Yellow",
      "Green",
      "Blue",
      "Purple"
    ],
    "stackSize": 5,
    "maxScore": 25
  },
  "1": {
    "name": "6 Suits",
    "suits": [
      "Red",
      "Yellow",
      "Green",
      "Blue",
      "Purple",
      "Teal"
    ],
    "stackSize": 5,
    "maxScore": 30
  },
  ...
  "2092": {
    "name": "Sudoku (4 Suits)",
    "suits": [
      "Red",
      "Yellow",
      "Green",
      "Blue"
    ],
    "stackSize": 4,
    "maxScore": 16
  },
 ...
```