### PR TITLE
Up or Down: Detect Trash 1/5 when start card is played

### DIFF
--- a/packages/game/src/rules/variants/reversible.ts
+++ b/packages/game/src/rules/variants/reversible.ts
@@ -113,9 +113,8 @@ function isCardDead(
     }
   }
 
-  // In "Up or Down", check if start card has been played.
-  // In this case, the direction might be forced if we are checking for a 1 or 5, since we cannot
-  // start with the 1 or 5 itself.
+  // In "Up or Down", check if start card has been played. In this case, the direction might be
+  // forced if we are checking for a 1 or 5, since we cannot start with the 1 or 5 itself.
   if (impliedDirection === StackDirection.Undecided) {
     for (const cardState of deck) {
       if (


### PR DESCRIPTION
This fixes bug #2990.

Since I was the one who reworked the reversible.ts code the last time, I felt responsible for fixing the bug I apparently introduced.