### PR TITLE
Fix history links not working on Tagged Games tab

### DIFF
--- a/server/src/views/history.tmpl
+++ b/server/src/views/history.tmpl
@@ -80,7 +80,8 @@
                 {{ end }}"
               >
                 {{ range $index2, $results2 := .PlayerNames }}
-                  {{- if $index2 }}, {{ end }}{{ $results2 -}}
+                  {{- if $index2 }},{{ end }}
+                  {{ $results2 -}}
                 {{ end }}
               </a>
             </td>


### PR DESCRIPTION
See for example https://hanab.live/tags/James
Click "ilikeeelst ,James ,Slacking ,str8tsknacker" link
Error: The player of "                  ilikeeelst                                  " does not exist in the database.