### PR TITLE
Add Chop Move border to cards with the 'bd' note

### DIFF
--- a/packages/game/src/abbreviations.ts
+++ b/packages/game/src/abbreviations.ts
@@ -26,6 +26,7 @@ export const CHOP_MOVED_NOTES = [
   "dtccm", // Duplicitous Tempo Clue Chop Move
   "atcm", // Assisted Trash Chop Move
   "ttcm", // Time Travel Chop Move
+  "bd", // Baton Discard
   // cspell:enable
 ] as const;
 


### PR DESCRIPTION
This PR gives cards with a `bd` note the Chop Move border.
The reason I chose the Chop Move border is that, unlike cards known by a (Layered) Gentleman's Discard, those known through a Baton Discard cannot be played immediately, so they shouldn't get the Finesse border.
This keeps in line with moves like 5NE where the partially known card gets a cm note.