### PR TITLE
docs: align OVERVIEW with server migration policy

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -15,7 +15,7 @@ Hanab Live follows a monorepo structure with a Go backend and a TypeScript/jQuer
 - **Caching/State:** [Redis](https://redis.io/) is used for transient data like banned IPs.
 - **Location:** The primary backend code is in the `server/` directory.
 
-> **Note:** There is a newer backend implementation in `packages/server` using Node.js, Fastify, and Drizzle ORM. The migration approach is incremental: production still runs the Go server, and server-side changes are currently expected to be mirrored in both implementations until cutover.
+> **Note:** There is a newer backend implementation in `packages/server` using Node.js, Fastify, and Drizzle ORM. The migration approach is incremental: production still runs the Go server, and server-side changes are currently expected to be mirrored in both implementations until migration is complete.
 
 ### Frontend
 


### PR DESCRIPTION
This is a tiny docs-only follow-up to the migration guidance added in 2dcb2406.

It updates one note in OVERVIEW.md to explicitly describe the current approach:
- Go server remains production.
- TypeScript server migration is incremental.
- Server-side changes are mirrored in both implementations until cutover.