### PR TITLE
fix: add missing migration script for user_identity_tokens table

### DIFF
--- a/server/migrate_user_identity_tokens_add_hashing.sql
+++ b/server/migrate_user_identity_tokens_add_hashing.sql
@@ -1,0 +1,11 @@
+CREATE TABLE user_identity_tokens (
+    user_id           INTEGER      NOT NULL  PRIMARY KEY,
+    token_hash        TEXT         NOT NULL, /* Argon2 hash */
+    token_lookup_hash TEXT         NOT NULL  UNIQUE, /* keyed lookup hash */
+    expires_at        TIMESTAMPTZ  NOT NULL,
+    datetime_created  TIMESTAMPTZ  NOT NULL  DEFAULT NOW(),
+    datetime_updated  TIMESTAMPTZ  NOT NULL  DEFAULT NOW(),
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+CREATE INDEX user_identity_tokens_index_token_lookup_hash ON user_identity_tokens (token_lookup_hash);
+CREATE INDEX user_identity_tokens_index_expires_at ON user_identity_tokens (expires_at);


### PR DESCRIPTION
## Summary

- PR #3072 deployed the identity token feature but did not include a migration script to create the `user_identity_tokens` table in the production database
- The `database_schema.sql` changes can't be run against prod (it's a destructive full-rebuild), and no standalone migration was provided
- As a result, `/token` fails immediately with the generic error modal because every DB call hits a non-existent table
- This PR adds `server/migrate_user_identity_tokens_add_hashing.sql`, following the same convention as `server/migrate_sound_move.sql` from #3030, to create the table with the correct final schema