### PR TITLE
Fix bug #2855 of hanabi-live

### DIFF
--- a/packages/client/src/game/reducers/notesReducer.ts
+++ b/packages/client/src/game/reducers/notesReducer.ts
@@ -172,15 +172,8 @@ export function noteHasMeaning(variant: Variant, note: CardNote): boolean {
 }
 
 export function parseNote(variant: Variant, text: string): CardNote {
-  const lastPipeIndex = text.lastIndexOf("|");
-
-  // No special handling is needed for the -1 case.
-  const textAfterLastPipe = text.slice(lastPipeIndex + 1);
-
-  // We make all letters lowercase to simply the matching logic below.
-  const fullNote = textAfterLastPipe.toLowerCase().trim();
-
-  const keywords = getNoteKeywords(fullNote);
+  // use the full note as keywords, since the parsing logic is handled in getNoteKeywords.
+  const keywords = getNoteKeywords(text.toLowerCase().trim());
   const possibilities = noteIdentity.getPossibilitiesFromKeywords(
     variant,
     keywords,

--- a/packages/client/src/game/reducers/notesReducer.ts
+++ b/packages/client/src/game/reducers/notesReducer.ts
@@ -172,7 +172,7 @@ export function noteHasMeaning(variant: Variant, note: CardNote): boolean {
 }
 
 export function parseNote(variant: Variant, text: string): CardNote {
-  // use the full note as keywords, since the parsing logic is handled in getNoteKeywords.
+  // Use the full note as keywords, since the parsing logic is handled in getNoteKeywords.
   const keywords = getNoteKeywords(text.toLowerCase().trim());
   const possibilities = noteIdentity.getPossibilitiesFromKeywords(
     variant,


### PR DESCRIPTION
I fix issue https://github.com/Hanabi-Live/hanabi-live/issues/2885. 
Now notes parser can read and handle cases with a protected note and a common note after '|'.
For example:
1. Player A notes one of his card(called X) [cm].
2. Player A notes card X, appended 'y2'.

What's happen now:
**Before:**
Card X only appears as y2, without chop move block surrounded.
**After:**
Card X correctly appears as y2 with chop move block surrounded.

Other cases, for example, [f] and 'r24', [cm] and 'bg35', handles correctly as well.