### PR TITLE
Note hotkeys now strip prose, keeping only UI-affecting content.

### DIFF
--- a/packages/client/src/game/ui/HanabiCard.ts
+++ b/packages/client/src/game/ui/HanabiCard.ts
@@ -1279,10 +1279,6 @@ export class HanabiCard extends Konva.Group implements NodeWithTooltip, UICard {
     return brackets.join(" ");
   }
 
-  /**
-   * Returns true if the note string sets any of the border-overriding fields:
-   * chopMoved, finessed, or discardPermission.
-   */
   isBorderAffecting(noteString: string): boolean {
     const parsed = parseNote(this.variant, noteString);
     return parsed.chopMoved || parsed.finessed || parsed.discardPermission;
@@ -1290,9 +1286,9 @@ export class HanabiCard extends Konva.Group implements NodeWithTooltip, UICard {
 
   updateNote(
     noteAdded: string,
-    updateFunc: (a: string, b: string) => string,
-    keepLast = false,
-    protect = true,
+    updateFunc: (a: string, b: string) => string, // how to combine last pipe section and noteAdded
+    keepLast = false, // true to repeat (and add to) the last pipe section
+    protect = true, // true to add [] to meaningful updates
     stripProse = false, // true to strip prose and conflicting border tokens
   ): void {
     const existingNote =

--- a/packages/client/src/game/ui/HanabiCard.ts
+++ b/packages/client/src/game/ui/HanabiCard.ts
@@ -1270,11 +1270,30 @@ export class HanabiCard extends Konva.Group implements NodeWithTooltip, UICard {
     return noteString;
   }
 
+  /**
+   * Strips all content from a note string that is not inside square brackets.
+   * e.g. "[cm] some prose [r4] more prose" → "[cm] [r4]"
+   */
+  static stripProse(noteString: string): string {
+    const brackets = noteString.match(/\[[^\]]*]/g) ?? [];
+    return brackets.join(" ");
+  }
+
+  /**
+   * Returns true if the note string sets any of the border-overriding fields:
+   * chopMoved, finessed, or discardPermission.
+   */
+  isBorderAffecting(noteString: string): boolean {
+    const parsed = parseNote(this.variant, noteString);
+    return parsed.chopMoved || parsed.finessed || parsed.discardPermission;
+  }
+
   updateNote(
     noteAdded: string,
-    updateFunc: (a: string, b: string) => string, // how to combine last pipe section and noteAdded
-    keepLast = false, // true to repeat (and add to) the last pipe section
-    protect = true, // true to add [] to meaningful updates
+    updateFunc: (a: string, b: string) => string,
+    keepLast = false,
+    protect = true,
+    stripProse = false, // true to strip prose and conflicting border tokens
   ): void {
     const existingNote =
       globals.state.notes.ourNotes[this.state.order]?.text ?? "";
@@ -1284,7 +1303,18 @@ export class HanabiCard extends Konva.Group implements NodeWithTooltip, UICard {
     const currentNoteString = noteText.slice(lastPipe + 1).trim();
     const noteString = this.protectedNote(currentNoteString);
     const currentNote = parseNote(this.variant, noteString);
-    const newNoteString = updateFunc(noteString, note);
+    let newNoteString = updateFunc(noteString, note);
+
+    if (stripProse) {
+      newNoteString = HanabiCard.stripProse(newNoteString);
+      if (this.isBorderAffecting(note)) {
+        newNoteString = newNoteString
+          .split(/(?<=])\s+(?=\[)/)
+          .filter((token) => token === note || !this.isBorderAffecting(token))
+          .join(" ");
+      }
+    }
+
     const newNoteText = keepLast
       ? noteText
       : noteText.slice(0, Math.max(lastPipe, 0)).trim();
@@ -1312,13 +1342,21 @@ export class HanabiCard extends Konva.Group implements NodeWithTooltip, UICard {
   }
 
   appendNoteOnly(noteAdded: string): void {
-    this.updateNote(noteAdded, (a: string, b: string): string => `${a} ${b}`);
+    this.updateNote(
+      noteAdded,
+      (a: string, b: string): string => `${a} ${b}`,
+      false,
+      true,
+      true,
+    );
   }
 
   appendNote(noteAdded: string): void {
     this.updateNote(
       noteAdded,
       (a: string, b: string): string => `${a} ${b}`,
+      true,
+      true,
       true,
     );
   }


### PR DESCRIPTION
Hotkeys that produce an [f], [ptd], or [cm] border also replace any conflicting note content.

# Example 1 - [cm] hotkey used
- **Initial note**: "[r3] because partner would've totally done something different if this were r4"
- **Current result**: "[r3] because partner would've totally done something different if this were r4 | [r3] because partner would've totally done something different if this were r4 [cm]"
- **New result**: "[r3] because partner would've totally done something different if this were r4 | [r3] [cm]"

# Example 2 - [f] hotkey used
- **Initial note**: "[cm] I can't wait to blind play this [r3]"
- **Current result**: "[cm] I can't wait to blind play this [r3] | [cm] I can't wait to blind play this [r3] [f]"
- **New result**: "[cm] I can't wait to blind play this [r3] | [r3] [f]"