### PR TITLE
add /split, /splitauto and /sa command

### DIFF
--- a/docs/chat-commands.md
+++ b/docs/chat-commands.md
@@ -49,20 +49,20 @@ If you need general help with the website, then read the [features page](feature
 
 ## Pre-game Commands (table-owner-only)
 
-| Command | Description |
-| --- | --- |
-| `/impostor` | Randomly tells one of the players they are an impostor and the others they are crew-mates. |
-| `/kick [username]` | Remove a player from the table |
-| `/s` | Automatically start the game when the next person joins |
-| `/s2` | Automatically start the game when it has 2 players |
-| `/s3` | Automatically start the game when it has 3 players |
-| `/s4` | Automatically start the game when it has 4 players |
-| `/s5` | Automatically start the game when it has 5 players |
-| `/s6` | Automatically start the game when it has 6 players |
-| `/setvariant [variant]` | Change the variant of the current game |
-| `/startin [minutes]` | Automatically start the game in the provided amount of minutes |
+| Command                              | Description                                                                                                                   |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| `/impostor`                          | Randomly tells one of the players they are an impostor and the others they are crew-mates.                                    |
+| `/kick [username]`                   | Remove a player from the table                                                                                                |
+| `/s`                                 | Automatically start the game when the next person joins                                                                       |
+| `/s2`                                | Automatically start the game when it has 2 players                                                                            |
+| `/s3`                                | Automatically start the game when it has 3 players                                                                            |
+| `/s4`                                | Automatically start the game when it has 4 players                                                                            |
+| `/s5`                                | Automatically start the game when it has 5 players                                                                            |
+| `/s6`                                | Automatically start the game when it has 6 players                                                                            |
+| `/setvariant [variant]`              | Change the variant of the current game                                                                                        |
+| `/startin [minutes]`                 | Automatically start the game in the provided amount of minutes                                                                |
 | `/split [username1] [username2] ...` | Move specified players to a new lobby with the same settings. The first player in the list becomes the owner of the new lobby |
-| `/splitauto` or `/sa` | Automatically split players into two lobbies based on total game count |
+| `/splitauto` or `/sa`                | Automatically split players into two lobbies based on total game count                                                        |
 
 <br />
 

--- a/docs/chat-commands.md
+++ b/docs/chat-commands.md
@@ -49,18 +49,20 @@ If you need general help with the website, then read the [features page](feature
 
 ## Pre-game Commands (table-owner-only)
 
-| Command                 | Description                                                                                |
-| ----------------------- | ------------------------------------------------------------------------------------------ |
-| `/impostor`             | Randomly tells one of the players they are an impostor and the others they are crew-mates. |
-| `/kick [username]`      | Remove a player from the table                                                             |
-| `/s`                    | Automatically start the game when the next person joins                                    |
-| `/s2`                   | Automatically start the game when it has 2 players                                         |
-| `/s3`                   | Automatically start the game when it has 3 players                                         |
-| `/s4`                   | Automatically start the game when it has 4 players                                         |
-| `/s5`                   | Automatically start the game when it has 5 players                                         |
-| `/s6`                   | Automatically start the game when it has 6 players                                         |
-| `/setvariant [variant]` | Change the variant of the current game                                                     |
-| `/startin [minutes]`    | Automatically start the game in the provided amount of minutes                             |
+| Command | Description |
+| --- | --- |
+| `/impostor` | Randomly tells one of the players they are an impostor and the others they are crew-mates. |
+| `/kick [username]` | Remove a player from the table |
+| `/s` | Automatically start the game when the next person joins |
+| `/s2` | Automatically start the game when it has 2 players |
+| `/s3` | Automatically start the game when it has 3 players |
+| `/s4` | Automatically start the game when it has 4 players |
+| `/s5` | Automatically start the game when it has 5 players |
+| `/s6` | Automatically start the game when it has 6 players |
+| `/setvariant [variant]` | Change the variant of the current game |
+| `/startin [minutes]` | Automatically start the game in the provided amount of minutes |
+| `/split [username1] [username2] ...` | Move specified players to a new lobby with the same settings. The first player in the list becomes the owner of the new lobby |
+| `/splitauto` or `/sa` | Automatically split players into two lobbies based on total game count |
 
 <br />
 

--- a/server/src/chat_command.go
+++ b/server/src/chat_command.go
@@ -29,6 +29,8 @@ func chatCommandInit() {
 	chatCommandMap["startin"] = chatStartIn
 	chatCommandMap["kick"] = chatKick
 	chatCommandMap["split"] = chatSplit
+	chatCommandMap["splitauto"] = chatSplitAuto
+	chatCommandMap["sa"] = chatSplitAuto
 	chatCommandMap["impostor"] = chatImpostor
 
 	// Table-only commands (pregame or game)

--- a/server/src/chat_command.go
+++ b/server/src/chat_command.go
@@ -28,6 +28,7 @@ func chatCommandInit() {
 	chatCommandMap["si"] = chatStartIn
 	chatCommandMap["startin"] = chatStartIn
 	chatCommandMap["kick"] = chatKick
+	chatCommandMap["split"] = chatSplit
 	chatCommandMap["impostor"] = chatImpostor
 
 	// Table-only commands (pregame or game)

--- a/server/src/chat_split.go
+++ b/server/src/chat_split.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Hanabi-Live/hanabi-live/logger"
+)
+
+const splitLobbySuffix = " (split)"
+
+// /split [username] [username] ...
+func chatSplit(ctx context.Context, s *Session, d *CommandData, t *Table, cmd string) {
+	chatServerSend(ctx, NotInGameFail, d.Room, d.NoTablesLock)
+}
+
+func commandTableSplit(ctx context.Context, s *Session, d *CommandData, tableID uint64) {
+	// Acquire the tables lock first so that we can safely create a new table while holding
+	// the source table lock.
+	tables.Lock(ctx)
+	defer tables.Unlock(ctx)
+
+	t, exists := getTableAndLock(ctx, s, tableID, true, false)
+	if !exists {
+		return
+	}
+	defer t.Unlock(ctx)
+
+	if t.Running {
+		chatServerSend(ctx, NotStartedFail, d.Room, true)
+		return
+	}
+
+	if s.UserID != t.OwnerID {
+		chatServerSend(ctx, NotOwnerFail, d.Room, true)
+		return
+	}
+
+	if len(d.Args) == 0 {
+		msg := "The format of the /split command is: /split [username] [username] ..."
+		chatServerSend(ctx, msg, d.Room, true)
+		return
+	}
+
+	selectedPlayers := make([]*Player, 0, len(d.Args))
+	selectedNames := make([]string, 0, len(d.Args))
+	seenNames := make(map[string]struct{})
+	for _, arg := range d.Args {
+		normalized := normalizeString(arg)
+		if _, ok := seenNames[normalized]; ok {
+			chatServerSend(ctx, "You cannot list the same player more than once in /split.", d.Room, true)
+			return
+		}
+		seenNames[normalized] = struct{}{}
+
+		var matchedPlayer *Player
+		for _, p := range t.Players {
+			if normalizeString(p.Name) == normalized {
+				matchedPlayer = p
+				break
+			}
+		}
+		if matchedPlayer == nil {
+			chatServerSend(ctx, "\""+arg+"\" is not joined to this table.", d.Room, true)
+			return
+		}
+
+		selectedPlayers = append(selectedPlayers, matchedPlayer)
+		selectedNames = append(selectedNames, matchedPlayer.Name)
+	}
+
+	if len(selectedPlayers) > t.MaxPlayers {
+		chatServerSend(ctx,
+			"You cannot split more than "+strconv.Itoa(t.MaxPlayers)+" players into one lobby.",
+			d.Room,
+			true,
+		)
+		return
+	}
+
+	selectedIDs := make(map[int]struct{}, len(selectedPlayers))
+	for _, p := range selectedPlayers {
+		selectedIDs[p.UserID] = struct{}{}
+	}
+
+	remainingPlayers := make([]*Player, 0, len(t.Players)-len(selectedPlayers))
+	for _, p := range t.Players {
+		if _, ok := selectedIDs[p.UserID]; !ok {
+			remainingPlayers = append(remainingPlayers, p)
+		}
+	}
+
+	newTableName := makeSplitTableName(t.Name)
+	newTable := NewTable(newTableName, selectedPlayers[0].UserID)
+	newOptions := *t.Options
+	newTable.Options = &newOptions
+	newTable.Visible = t.Visible
+	newTable.PasswordHash = t.PasswordHash
+	newTable.MaxPlayers = t.MaxPlayers
+	newTable.Players = make([]*Player, 0, len(selectedPlayers))
+	newTable.OwnerID = selectedPlayers[0].UserID
+	tables.Set(newTable.ID, newTable)
+
+	if !t.DatetimePlannedStart.IsZero() {
+		t.DatetimePlannedStart = time.Time{}
+		chatServerSend(ctx, "Automatic game start has been canceled.", t.GetRoomName(), true)
+	}
+
+	for _, p := range selectedPlayers {
+		movePlayerToSplitLobby(p, t, newTable)
+	}
+
+	if len(remainingPlayers) > 0 {
+		t.Players = remainingPlayers
+		if _, ok := selectedIDs[t.OwnerID]; ok {
+			t.OwnerID = remainingPlayers[0].UserID
+		}
+		t.NotifyPlayerChange()
+		notifyAllTable(t)
+	} else {
+		deleteTable(t)
+	}
+
+	newTable.DatetimeLastJoined = time.Now()
+	newTable.NotifyPlayerChange()
+	notifyAllTable(newTable)
+
+	for _, p := range selectedPlayers {
+		if p.Session != nil {
+			p.Session.NotifyTableJoined(newTable)
+		}
+	}
+
+	msg := s.Username + " split " + strings.Join(selectedNames, ", ") + " into a new lobby."
+	chatServerSend(ctx, msg, t.GetRoomName(), true)
+	chatServerSend(ctx, "This lobby was created by splitting " + t.Name + ".", newTable.GetRoomName(), true)
+
+	logger.Info(t.GetName() + "User \"" + s.Username + "\" split players into a new lobby named \"" +
+		newTableName + "\".")
+}
+
+func movePlayerToSplitLobby(p *Player, source *Table, destination *Table) {
+	if p.Session == nil {
+		p.Session = NewFakeSession(p.UserID, p.Name)
+	}
+
+	if p.Typing {
+		source.NotifyChatTyping(p.Name, false)
+		p.Typing = false
+	}
+
+	tables.DeletePlaying(p.UserID, source.ID)
+	tables.AddPlaying(p.UserID, destination.ID)
+	p.Present = true
+	p.Session.SetStatus(StatusPregame)
+	p.Session.SetTableID(destination.ID)
+	notifyAllUser(p.Session)
+	destination.Players = append(destination.Players, p)
+}
+
+func makeSplitTableName(sourceName string) string {
+	name := strings.TrimSpace(sourceName)
+	if len(name)+len(splitLobbySuffix) > MaxGameNameLength {
+		name = name[0 : MaxGameNameLength-len(splitLobbySuffix)]
+	}
+	return strings.TrimSpace(name + splitLobbySuffix)
+}

--- a/server/src/chat_splitauto.go
+++ b/server/src/chat_splitauto.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/Hanabi-Live/hanabi-live/logger"
+)
+
+// /splitauto - Automatically split players into two lobbies based on game count
+func chatSplitAuto(ctx context.Context, s *Session, d *CommandData, t *Table, cmd string) {
+	chatServerSend(ctx, NotInGameFail, d.Room, d.NoTablesLock)
+}
+
+func commandTableSplitAuto(ctx context.Context, s *Session, d *CommandData, tableID uint64) {
+	// Acquire the tables lock first so that we can safely get the table and determine players to move
+	tables.Lock(ctx)
+
+	t, exists := getTableAndLock(ctx, s, tableID, true, false)
+	if !exists {
+		tables.Unlock(ctx)
+		return
+	}
+
+	if t.Running {
+		t.Unlock(ctx)
+		tables.Unlock(ctx)
+		chatServerSend(ctx, NotStartedFail, d.Room, true)
+		return
+	}
+
+	if s.UserID != t.OwnerID {
+		t.Unlock(ctx)
+		tables.Unlock(ctx)
+		chatServerSend(ctx, NotOwnerFail, d.Room, true)
+		return
+	}
+
+	if len(t.Players) < 2 {
+		t.Unlock(ctx)
+		tables.Unlock(ctx)
+		chatServerSend(ctx, "There must be at least 2 players to split.", d.Room, true)
+		return
+	}
+
+	// Pre-compute game counts to avoid repeated nil checks during sort
+	gameCounts := make([]int, len(t.Players))
+	playerMap := make(map[*Player]int, len(t.Players))
+	for i, p := range t.Players {
+		if p.Stats != nil {
+			gameCounts[i] = p.Stats.NumGames
+		}
+		playerMap[p] = i
+	}
+
+	// Sort players by NumGames descending (highest games first)
+	sortedPlayers := make([]*Player, len(t.Players))
+	copy(sortedPlayers, t.Players)
+	sort.Slice(sortedPlayers, func(i, j int) bool {
+		return gameCounts[playerMap[sortedPlayers[i]]] > gameCounts[playerMap[sortedPlayers[j]]]
+	})
+
+	// Determine which group to move (the one without the owner)
+	movedGroup := getGroupToMove(sortedPlayers, t.OwnerID)
+
+	if len(movedGroup) == 0 || len(movedGroup) > t.MaxPlayers {
+		chatServerSend(ctx,
+			"Cannot split: resulting group is empty or exceeds player limit.",
+			d.Room,
+			true,
+		)
+		return
+	}
+
+	// Extract player names and delegate to /split
+	movedGroupNames := getPlayerNames(movedGroup)
+	logger.Info(t.GetName() + "User \"" + s.Username + "\" initiated automatic split by game count. " +
+		"Moving: " + strings.Join(movedGroupNames, ", "))
+
+	// Release locks before delegating to /split so that commandTableSplit can
+	// acquire locks in its own correct order (tables -> table) without deadlock.
+	t.Unlock(ctx)
+	tables.Unlock(ctx)
+
+	// Use the existing /split command logic by setting d.Args and calling commandTableSplit
+	d.Args = movedGroupNames
+	commandTableSplit(ctx, s, d, tableID)
+}
+
+// getGroupToMove returns the group of players that should be moved (not containing the owner).
+// Players are already sorted by game count (highest first).
+// Owner stays in current lobby with their group; the other group moves.
+// If odd number of players, owner's group gets the extra player.
+func getGroupToMove(sortedPlayers []*Player, ownerID int) []*Player {
+	if len(sortedPlayers) == 0 {
+		return []*Player{}
+	}
+	splitPoint := len(sortedPlayers) / 2
+	topHalf := sortedPlayers[:splitPoint]
+	bottomHalf := sortedPlayers[splitPoint:]
+
+	// Split at midpoint; bottomHalf will contain the lower game counts because
+	// `sortedPlayers` is descending by NumGames. Move the half that does NOT
+	// contain the owner.
+	for _, p := range topHalf {
+		if p.UserID == ownerID {
+			return bottomHalf
+		}
+	}
+	return topHalf
+}
+
+// getPlayerNames returns a slice of player names from a slice of players
+func getPlayerNames(players []*Player) []string {
+	names := make([]string, 0, len(players))
+	for _, p := range players {
+		names = append(names, p.Name)
+	}
+	return names
+}

--- a/server/src/command_chat.go
+++ b/server/src/command_chat.go
@@ -189,6 +189,13 @@ func commandChatTable(ctx context.Context, s *Session, d *CommandData) {
 		tableID = v
 	}
 
+	// Handle /split before the message is added to chat history.
+	if command, args := chatParseCommand(d.Msg); command == "split" {
+		d.Args = args
+		commandTableSplit(ctx, s, d, tableID)
+		return
+	}
+
 	t, exists := getTableAndLock(ctx, s, tableID, !d.NoTableLock, !d.NoTablesLock)
 	if !exists {
 		return

--- a/server/src/command_chat.go
+++ b/server/src/command_chat.go
@@ -196,6 +196,13 @@ func commandChatTable(ctx context.Context, s *Session, d *CommandData) {
 		return
 	}
 
+	// Handle /splitauto before the message is added to chat history.
+	if command, args := chatParseCommand(d.Msg); command == "splitauto" || command == "sa" {
+		d.Args = args
+		commandTableSplitAuto(ctx, s, d, tableID)
+		return
+	}
+
 	t, exists := getTableAndLock(ctx, s, tableID, !d.NoTableLock, !d.NoTablesLock)
 	if !exists {
 		return


### PR DESCRIPTION
When playing Hanabi, sometimes your lobby fills up to a point where it makes sense to split the table into two new groups. Those new commands, `/split [username1] [username2]...`, `/splitauto` and its alias `/sa` intend to make this a bit easier.

- `/split` creates a new lobby with the users listed
- `/splitauto` and `/sa` do the same as `/split`, except that the users are automatically determined by total games count.

It would be ideal for it to be possible for spectators to be included in those commands, but that could allow for forced participation in games, which is undesirable. Maybe a button in chat like for suggested variants might be a solution for that in the future.

While I am a developer, I do not know Go, therefore all of this code has been written with the help of copilot. I have tested it and it seems to work, but I cant tell how well the code is written, or if it is correct besides the general logic.