### PR TITLE
Change arrow color of cm cards with HGroup feature

### DIFF
--- a/packages/client/src/game/ui/arrows.ts
+++ b/packages/client/src/game/ui/arrows.ts
@@ -26,6 +26,29 @@ import { drawPip } from "./drawPip";
 import { getCardOrStackBase } from "./getCardOrStackBase";
 import * as konvaHelpers from "./konvaHelpers";
 
+function getClueArrowColor(
+  element: Konva.Node | null,
+  preview: boolean,
+): string {
+  if (!(element instanceof HanabiCard)) {
+    return ARROW_COLOR.DEFAULT;
+  }
+
+  if (
+    element.state.numPositiveClues >= 2
+    || (element.state.numPositiveClues >= 1 && preview)
+  ) {
+    return ARROW_COLOR.RETOUCHED;
+  }
+
+  // if H-Group features are enabled, use a different color for cards that have been chop-moved
+  if (globals.lobby.settings.hyphenatedConventions && element.note.chopMoved) {
+    return ARROW_COLOR.CM_TOUCHED;
+  }
+
+  return ARROW_COLOR.DEFAULT;
+}
+
 export function hideAll(): void {
   let changed = false;
   for (const arrow of globals.elements.arrows) {
@@ -101,13 +124,8 @@ export function set(
     arrow.circle.hide();
     arrow.text.hide();
   } else {
-    // This is a clue arrow.
-    const color =
-      element instanceof HanabiCard
-      && (element.state.numPositiveClues >= 2
-        || (element.state.numPositiveClues >= 1 && preview))
-        ? ARROW_COLOR.RETOUCHED // Cards that are re-clued use a different color.
-        : ARROW_COLOR.DEFAULT; // Freshly touched cards use the default color.
+    // This is a clue arrow. Compute color using a small helper for clarity.
+    const color = getClueArrowColor(element, preview);
 
     arrow.base.stroke(color);
     arrow.base.fill(color);

--- a/packages/client/src/game/ui/arrows.ts
+++ b/packages/client/src/game/ui/arrows.ts
@@ -34,6 +34,9 @@ function getClueArrowColor(
     return ARROW_COLOR.DEFAULT;
   }
 
+  // The arrow is drawn after the clue is given, so by this time `numPositiveClues` having a value
+  // of 2 means it had one clue already. During preview the clue is not applied yet, so if it has at
+  // least one positive clue on it already, it will be retouched by the next clue.
   if (
     element.state.numPositiveClues >= 2
     || (element.state.numPositiveClues >= 1 && preview)

--- a/packages/client/src/game/ui/constants.ts
+++ b/packages/client/src/game/ui/constants.ts
@@ -29,6 +29,7 @@ export const ARROW_COLOR = {
   /** Dark gray */
   RETOUCHED: "#737373",
 
+  /** Light gray */
   CM_TOUCHED: "#B9B9B9",
 
   /** Yellow */

--- a/packages/client/src/game/ui/constants.ts
+++ b/packages/client/src/game/ui/constants.ts
@@ -29,6 +29,8 @@ export const ARROW_COLOR = {
   /** Dark gray */
   RETOUCHED: "#737373",
 
+  CM_TOUCHED: "#B9B9B9",
+
   /** Yellow */
   HIGHLIGHT: "#ffdf00",
 } as const;


### PR DESCRIPTION
Did you ever get the focus of a clue wrong because the chop was chop moved? This PR changes the arrow color of chop moved cards to be light grey (`#737373`), between the color of untouched and touched cards. 

This is only enabled if the "Enable [H-Group](https://github.com/Hanabi-Live/hanabi-live/blob/main/docs/features.md#h-group-conventions) features" setting is enabled.

Note: when adding a cm note to a card while an arrow is visible, the arrow will not update and stay white. This should usually not be a problem since a clue that touches a card can not also chop move it. Having the arrow reappear will then show the correct color (e.g. go back and forth in history)