### PR TITLE
Allow omitting 0 before . for time in /si command

### DIFF
--- a/server/src/chat_pregame.go
+++ b/server/src/chat_pregame.go
@@ -63,7 +63,8 @@ func chatStartIn(ctx context.Context, s *Session, d *CommandData, t *Table, cmd 
 	}
 
 	var minutesToWait float64
-	if v, err := strconv.ParseFloat(d.Args[0], 64); err != nil {
+	// the `"0" +` adds a leading zero in case the user inputs something like ".5" to represent half a minute
+	if v, err := strconv.ParseFloat("0" + d.Args[0], 64); err != nil {
 		msg := "\"" + d.Args[0] + "\" is not a valid number."
 		chatServerSend(ctx, msg, d.Room, d.NoTablesLock)
 		return


### PR DESCRIPTION
This PR will allow the `/startin [time]` and `/si [time]` commands to accept a time that starts with `.`, e.g. `.5` for `0.5`.