### PR TITLE
Replace broken link to pips-reference script

### DIFF
--- a/public/standalone/pips-reference.html
+++ b/public/standalone/pips-reference.html
@@ -122,6 +122,6 @@
       <div class="loading">Loading pips...</div>
     </div>
 
-    <script src="../js/bundles/pips-reference.min.js"></script>
+    <script src="../../packages/client/src/standalone/pips-reference.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
The current link leads to a 404. This should fix it, but I haven't built it locally to test. Worst-case, it's still a 404.